### PR TITLE
Fix sample and documentation code regarding auto registration

### DIFF
--- a/docs/provider_memory.md
+++ b/docs/provider_memory.md
@@ -88,6 +88,7 @@ mbb.Do(builder => applicationLayer.GetTypes().Where(t => t.IsClass && !t.IsAbstr
                     .ForEach(find =>
                     {
                         Log.InfoFormat(CultureInfo.InvariantCulture, "Registering {0} in the bus", find.EventType);
+                        builder.Produce(find.EventType, x => x.DefaultTopic(x.Settings.MessageType.Name));
                         builder.Consume(find.EventType, x => x.Topic(x.MessageType.Name).WithConsumer(find.HandlerType));
                     })
                 );

--- a/src/Samples/Sample.DomainEvents.WebApi/Startup.cs
+++ b/src/Samples/Sample.DomainEvents.WebApi/Startup.cs
@@ -104,6 +104,7 @@ namespace Sample.DomainEvents.WebApi
                     .ToList()
                     .ForEach(find =>
                     {
+                        builder.Produce(find.EventType, x => x.DefaultTopic(x.Settings.MessageType.Name));
                         builder.Consume(find.EventType, x => x.Topic(x.MessageType.Name).WithConsumer(find.HandlerType));
                     })
                 )


### PR DESCRIPTION
This pull request fixes the same code and documentation regarding the `InMemoryBus` and the auto-registration for producers and consumers.

The existing code failed to register the producers, leading to an unusable example for newcomers.

Closes #40 

<!--
Thanks for contributing to the SlimMessageBus project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific transport or plugin: Mention the it shortname in square brackets
  e.g. "[Host.Kafka]", "[Host.AzureServiceBus]" or "[Host.Serialization.Json]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for XYZ" or "Fix wrongly handled exception"
  for a new plugin: "Initial contribution"
Examples:
- "[Host.AzureServiceBus] Add support for sessions"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the /docs?
- Did you sign-off your work:
  https://github.com/zarusz/SlimMessageBus/blob/master/CONTRIBUTING.md#sign-your-work
-->

