### PR TITLE
Fix for .AttachEvents() for an individual consumer

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -215,17 +215,17 @@ When you need to intercept a message that is delivered to a consumer, you can us
 mbb
    .Consume<SomeMessage>(x =>
    {
-       x.Topic("some-topic");
-       x.AttachEvents(events =>
-       {
-          // Invoke the action for the specified message type when arrived on the bus:
-          events.OnMessageArrived = (bus, consumerSettings, message, name, nativeMessage) => {
-             Console.WriteLine("The SomeMessage: {0} arrived on the topic/queue {1}", message, name);
-          }
-          events.OnMessageFault = (bus, consumerSettings, message, ex, nativeMessage) => {
+       x.Topic("some-topic")
+        .AttachEvents(events =>
+        {
+            // Invoke the action for the specified message type when arrived on the bus:
+            events.OnMessageArrived = (bus, consumerSettings, message, name, nativeMessage) => {
+                Console.WriteLine("The SomeMessage: {0} arrived on the topic/queue {1}", message, name);
+            }
+            events.OnMessageFault = (bus, consumerSettings, message, ex, nativeMessage) => {
 
-          };
-       });
+            };
+        });
     })
     .AttachEvents(events =>
     {

--- a/src/Host.Transport.Properties.xml
+++ b/src/Host.Transport.Properties.xml
@@ -4,6 +4,6 @@
 	<Import Project="Common.Properties.xml" />
 
 	<PropertyGroup>
-		<Version>1.11.1</Version>
+		<Version>1.11.2-rc1</Version>
 	</PropertyGroup>
 </Project>

--- a/src/SlimMessageBus.Host/Config/Fluent/AbstractConsumerBuilder.cs
+++ b/src/SlimMessageBus.Host/Config/Fluent/AbstractConsumerBuilder.cs
@@ -18,14 +18,5 @@ namespace SlimMessageBus.Host.Config
             MessageType = messageType;
             Settings = settings;
         }
-
-        public TBuilder AttachEvents<TBuilder>(Action<IConsumerEvents> eventsConfig)
-            where TBuilder : AbstractConsumerBuilder<T>
-        {
-            if (eventsConfig == null) throw new ArgumentNullException(nameof(eventsConfig));
-
-            eventsConfig(Settings);
-            return (TBuilder)this;
-        }
     }
 }

--- a/src/SlimMessageBus.Host/Config/Fluent/AbstractTopicConsumerBuilder.cs
+++ b/src/SlimMessageBus.Host/Config/Fluent/AbstractTopicConsumerBuilder.cs
@@ -22,5 +22,14 @@ namespace SlimMessageBus.Host.Config
             };
             Settings.Consumers.Add(ConsumerSettings);
         }
+
+        public TBuilder AttachEvents<TBuilder>(Action<IConsumerEvents> eventsConfig)
+            where TBuilder : AbstractTopicConsumerBuilder
+        {
+            if (eventsConfig == null) throw new ArgumentNullException(nameof(eventsConfig));
+
+            eventsConfig(ConsumerSettings);
+            return (TBuilder)this;
+        }
     }
 }

--- a/src/SlimMessageBus.Host/Config/Fluent/TopicConsumerBuilder.cs
+++ b/src/SlimMessageBus.Host/Config/Fluent/TopicConsumerBuilder.cs
@@ -116,5 +116,13 @@ namespace SlimMessageBus.Host.Config
             ConsumerSettings.Instances = numberOfInstances;
             return this;
         }
+
+        /// <summary>
+        /// Adds custom hooks for the consumer.
+        /// </summary>
+        /// <param name="eventsConfig"></param>
+        /// <returns></returns>
+        public TopicConsumerBuilder<TMessage> AttachEvents(Action<IConsumerEvents> eventsConfig)
+            => AttachEvents<TopicConsumerBuilder<TMessage>>(eventsConfig);
     }
 }

--- a/src/SlimMessageBus.Host/Config/Fluent/TopicHandlerBuilder.cs
+++ b/src/SlimMessageBus.Host/Config/Fluent/TopicHandlerBuilder.cs
@@ -38,5 +38,13 @@ namespace SlimMessageBus.Host.Config
             ConsumerSettings.Instances = numberOfInstances;
             return this;
         }
+
+        /// <summary>
+        /// Adds custom hooks for the handler.
+        /// </summary>
+        /// <param name="eventsConfig"></param>
+        /// <returns></returns>
+        public TopicHandlerBuilder<TRequest, TResponse> AttachEvents(Action<IConsumerEvents> eventsConfig)
+            => AttachEvents<TopicHandlerBuilder<TRequest, TResponse>>(eventsConfig);
     }
 }


### PR DESCRIPTION
Following the issue found on Gitter chat. The .AttachEvents() on the .Consume() registered the hooks at the global/bus level rather than at an individual consumer level.

Signed-off-by: Tomasz Maruszak <maruszaktomasz@gmail.com>

<!--
Thanks for contributing to the SlimMessageBus project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific transport or plugin: Mention the it shortname in square brackets
  e.g. "[Host.Kafka]", "[Host.AzureServiceBus]" or "[Host.Serialization.Json]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for XYZ" or "Fix wrongly handled exception"
  for a new plugin: "Initial contribution"
Examples:
- "[Host.AzureServiceBus] Add support for sessions"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the /docs?
- Did you sign-off your work:
  https://github.com/zarusz/SlimMessageBus/blob/master/CONTRIBUTING.md#sign-your-work
-->

