### PR TITLE
By default do not emit the assembly strong name in AssemblyQualified…

### DIFF
--- a/src/SlimMessageBus.Host/MessageTypeResolver/AssemblyQualifiedNameMessageTypeResolver.cs
+++ b/src/SlimMessageBus.Host/MessageTypeResolver/AssemblyQualifiedNameMessageTypeResolver.cs
@@ -1,14 +1,48 @@
 ﻿namespace SlimMessageBus.Host
 {
+    using SlimMessageBus.Host.Collections;
     using System;
+    using System.Text.RegularExpressions;
 
     /// <summary>
     /// <see cref="IMessageTypeResolver"/> that uses the <see cref="Type.AssemblyQualifiedName"/> for the message type string passed in the message header.
     /// </summary>
     public class AssemblyQualifiedNameMessageTypeResolver : IMessageTypeResolver
     {
-        public string ToName(Type messageType) => messageType?.AssemblyQualifiedName ?? throw new ArgumentNullException(nameof(messageType));
+        private static readonly Regex RedundantAssemblyTokens = new(@"\, (Version|Culture|PublicKeyToken)\=([\w\d.]+)");
 
-        public Type ToType(string name) => Type.GetType(name ?? throw new ArgumentNullException(nameof(name)));
+        /// <summary>
+        /// Determines wheather to emit the Version, Culture and PublicKeyToken along with the Assembly name (for strong assembly naming).
+        /// </summary>
+        public bool EmitAssemblyStrongName { get; set; } = false;
+
+        private readonly SafeDictionaryWrapper<Type, string> toNameCache;
+        private readonly SafeDictionaryWrapper<string, Type> toTypeCache;
+
+        public AssemblyQualifiedNameMessageTypeResolver()
+        {
+            toNameCache = new SafeDictionaryWrapper<Type, string>(ToNameInternal);
+            toTypeCache = new SafeDictionaryWrapper<string, Type>(ToTypeInternal);
+        }
+
+        private string ToNameInternal(Type messageType)
+        {
+            var assemblyQualifiedName = messageType?.AssemblyQualifiedName ?? throw new ArgumentNullException(nameof(messageType));
+
+            if (EmitAssemblyStrongName)
+            {
+                return assemblyQualifiedName;
+            }
+
+            var reducedName = RedundantAssemblyTokens.Replace(assemblyQualifiedName, string.Empty);
+
+            return reducedName;
+        }
+
+        private Type ToTypeInternal(string name) => Type.GetType(name ?? throw new ArgumentNullException(nameof(name)));
+
+        public string ToName(Type messageType) => toNameCache.GetOrAdd(messageType);
+
+        public Type ToType(string name) => toTypeCache.GetOrAdd(name);
     }
 }

--- a/src/SlimMessageBus.Host/MessageTypeResolver/IMessageTypeResolver.cs
+++ b/src/SlimMessageBus.Host/MessageTypeResolver/IMessageTypeResolver.cs
@@ -4,7 +4,7 @@
 
     public interface IMessageTypeResolver
     {
-        string ToName(Type message);
+        string ToName(Type messageType);
         Type ToType(string name);
     }
 }

--- a/src/Tests/SlimMessageBus.Host.Test.Common/Messages/SomeMessage2.cs
+++ b/src/Tests/SlimMessageBus.Host.Test.Common/Messages/SomeMessage2.cs
@@ -1,0 +1,6 @@
+﻿namespace SlimMessageBus.Host.Test.Messages
+{
+    public class SomeMessage2
+    {
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Test/AssemblyQualifiedNameMessageTypeResolverTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/AssemblyQualifiedNameMessageTypeResolverTest.cs
@@ -1,22 +1,72 @@
 ﻿namespace SlimMessageBus.Host.Test
 {
     using FluentAssertions;
+    using SlimMessageBus.Host.Test.Messages;
+    using System;
+    using System.Collections.Generic;
     using Xunit;
 
     public class AssemblyQualifiedNameMessageTypeResolverTest
     {
-        [Fact]
-        public void ItWorks()
+        [Theory]
+        [InlineData(typeof(SomeMessage))]
+        [InlineData(typeof((int Key, string Value)))]
+        [InlineData(typeof(SomeMessage2))]
+        [InlineData(typeof(int))]
+        public void ConvertsAnyTypeBackAndForth(Type messageType)
         {
             // arrange
             var subject = new AssemblyQualifiedNameMessageTypeResolver();
-            var name = subject.ToName(typeof(SomeMessage));
+            var name = subject.ToName(messageType);
 
             // act
             var type = subject.ToType(name);
 
             // assert
-            type.Should().Be(typeof(SomeMessage));
+            type.Should().Be(messageType);
+        }
+
+        [Fact]
+        public void ConvertsTypeToName()
+        {
+            // arrange
+            var subject = new AssemblyQualifiedNameMessageTypeResolver();
+
+            // act
+            var name = subject.ToName(typeof(IEnumerable<SomeMessage2>));
+
+            // assert
+            name.Should().Be("System.Collections.Generic.IEnumerable`1[[SlimMessageBus.Host.Test.Messages.SomeMessage2, SlimMessageBus.Host.Test.Common]], System.Private.CoreLib");
+        }
+
+        [Theory]
+        [InlineData("SlimMessageBus.Host.Test.Messages.SomeMessage2, SlimMessageBus.Host.Test.Common", typeof(SomeMessage2))]
+        [InlineData("System.Collections.Generic.IEnumerable`1[[SlimMessageBus.Host.Test.Messages.SomeMessage2, SlimMessageBus.Host.Test.Common]], System.Private.CoreLib", typeof(IEnumerable<SomeMessage2>))]
+        public void ConvertsNameToType(string name, Type messageType)
+        {
+            // arrange
+            var subject = new AssemblyQualifiedNameMessageTypeResolver();
+
+            // act
+            var type = subject.ToType(name);
+
+            // assert
+            type.Should().Be(messageType);
+        }
+
+        [Theory]
+        [InlineData("System.Collections.Generic.IEnumerable`1[[SlimMessageBus.Host.Test.Messages.SomeMessage3, SlimMessageBus.Host.Test.Common]], System.Private.CoreLib")]
+        [InlineData("System.Collections.Generic.IEnumerable`1[[SlimMessageBus.Host.Test.Messages.SomeMessage2]], System.Private.CoreLib")]
+        public void ConvertsInvalidNameToNullType(string name)
+        {
+            // arrange
+            var subject = new AssemblyQualifiedNameMessageTypeResolver();
+
+            // act
+            var type = subject.ToType(name);
+
+            // assert
+            type.Should().BeNull();
         }
     }
 }

--- a/src/Tests/SlimMessageBus.Host.Test/SlimMessageBus.Host.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Test/SlimMessageBus.Host.Test.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.Json\SlimMessageBus.Host.Serialization.Json.csproj" />
     <ProjectReference Include="..\..\SlimMessageBus.Host\SlimMessageBus.Host.csproj" />
     <ProjectReference Include="..\..\SlimMessageBus\SlimMessageBus.csproj" />
+    <ProjectReference Include="..\SlimMessageBus.Host.Test.Common\SlimMessageBus.Host.Test.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
By default do not emit the assembly strong name in  AssemblyQualifiedNameMessageTypeResolver.

Signed-off-by: Tomasz Maruszak <maruszaktomasz@gmail.com>
