### PR TITLE
change MSDependencyInjection to MsDependencyInjection in SlimMessageB…

### DIFF
--- a/src/SlimMessageBus.Host.AspNetCore/SlimMessageBus.Host.AspNetCore.csproj
+++ b/src/SlimMessageBus.Host.AspNetCore/SlimMessageBus.Host.AspNetCore.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SlimMessageBus.Host.MSDependencyInjection\SlimMessageBus.Host.MsDependencyInjection.csproj" />
+    <ProjectReference Include="..\SlimMessageBus.Host.MsDependencyInjection\SlimMessageBus.Host.MsDependencyInjection.csproj" />
     <ProjectReference Include="..\SlimMessageBus.Host\SlimMessageBus.Host.csproj" />
   </ItemGroup>
 

--- a/src/Tests/SlimMessageBus.Host.Integration.Test/HybridTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Integration.Test/HybridTests.cs
@@ -34,6 +34,7 @@ namespace SlimMessageBus.Host.Integration
         Unity = 3,
     }
 
+    [Trait("Category", "Integration")]
     public class HybridTests : IDisposable
     {
         private IDependencyResolver dependencyResolver;


### PR DESCRIPTION
…us.Host.AspNetCore csproj refrences

Signed-off-by: ahmad <achehre@yahoo.com>

Fix Unix File Path

[SlimMessageBus.Host.AspNetCore] rename(to lower-case) file path referenced in this project

I have an error on building all projects in Linux because Linux is case sensitive in the file path and there is a path in a SlimMessageBus.Host.AspNetCore project is in upper case but should be lower in character.

