### PR TITLE
mark Hybrid tests as integration in test category

### DIFF
--- a/src/Tests/SlimMessageBus.Host.Integration.Test/HybridTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Integration.Test/HybridTests.cs
@@ -34,6 +34,7 @@ namespace SlimMessageBus.Host.Integration
         Unity = 3,
     }
 
+    [Trait("Category", "Integration")]
     public class HybridTests : IDisposable
     {
         private IDependencyResolver dependencyResolver;


### PR DESCRIPTION
Signed-off-by: ahmad <achehre@yahoo.com>

Change Hybrid Test Category

Mark Hybrid tests as integration in the test category. Because it needs the Azure secret key to run.
