### PR TITLE
Default consumer type to the generic interface

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -236,7 +236,9 @@ public class SomeConsumer : IConsumer<SomeMessage>
 }
 ```
 
-The `SomeConsumer` needs to be registered in your DI container. The SMB runtime will ask the chosen DI to provide the desired number of consumer instances. Any collaborators of the consumer will be resolved according to your DI configuration.
+The `SomeConsumer` needs to be registered in the DI container. The SMB runtime will ask the DI to provide the consumer instance.
+
+> When `.WithConsumer<TConsumer>()` is not declared, then a default consumer of type `IConsumer<TMessage>` will be assumed (since v2.0.0).
 
 Alternatively, if you do not want to implement the `IConsumer<SomeMessage>`, then you can provide the method name (2) or a delegate that calls the consumer method (3):
 
@@ -546,7 +548,9 @@ mbb.Handle<SomeRequest, SomeResponse>(x => x
   )
 ```
 
-> The same micro-service can both send the request and also be the handler of those requests.
+The same micro-service can both send the request and also be the handler of those requests.
+
+> When `.WithHandler<THandler>()` is not declared, then a default handler of type `IRequestHandler<TRequest, TResponse>` will be assumed (since v2.0.0).
 
 ## Static accessor
 
@@ -596,6 +600,22 @@ services.AddSlimMessageBus((mbb, svp) =>
 services.AddMessageBusConsumersFromAssembly(Assembly.GetExecutingAssembly());
 services.AddMessageBusInterceptorsFromAssembly(Assembly.GetExecutingAssembly());
 services.AddMessageBusConfiguratorsFromAssembly(Assembly.GetExecutingAssembly());
+```
+
+Consider the following example:
+
+```cs
+// Given a consumer that is found:
+public class SomeMessageConsumer : IConsumer<SomeMessage>
+{
+}
+
+// When auto-registration is used:
+services.AddMessageBusConsumersFromAssembly(Assembly.GetExecutingAssembly());
+
+// Then it will cause the following MSDI setup:
+services.TryAddTransient<SomeMessageConsumer>();
+services.TryAddTransient<IConsumer<SomeMessage>, SomeMessageConsumer>();
 ```
 
 #### ASP.Net Core

--- a/src/Host.Interceptor.Properties.xml
+++ b/src/Host.Interceptor.Properties.xml
@@ -4,7 +4,7 @@
   <Import Project="Common.Properties.xml" />
 
   <PropertyGroup>
-    <Version>2.0.0-rc1</Version>
+    <Version>2.0.0-rc2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 </Project> 

--- a/src/Host.Transport.Properties.xml
+++ b/src/Host.Transport.Properties.xml
@@ -4,7 +4,7 @@
 	<Import Project="Common.Properties.xml" />
 
 	<PropertyGroup>
-		<Version>2.0.0-rc1</Version>
+		<Version>2.0.0-rc2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 </Project>

--- a/src/SlimMessageBus.Host/Config/ConsumerSettings.cs
+++ b/src/SlimMessageBus.Host/Config/ConsumerSettings.cs
@@ -24,11 +24,6 @@ public class ConsumerSettings : AbstractConsumerSettings, IMessageTypeConsumerIn
             .SingleOrDefault();
     }
 
-    public ConsumerSettings()
-    {
-        Invokers = new List<IMessageTypeConsumerInvokerSettings>();
-    }
-
     /// Type of consumer that is configured (subscriber or request handler).
     /// </summary>
     public ConsumerMode ConsumerMode { get; set; }
@@ -39,7 +34,7 @@ public class ConsumerSettings : AbstractConsumerSettings, IMessageTypeConsumerIn
     /// <summary>
     /// List of all declared consumers that handle any derived message type of the declared message type.
     /// </summary>
-    public IList<IMessageTypeConsumerInvokerSettings> Invokers { get; }
+    public ISet<IMessageTypeConsumerInvokerSettings> Invokers { get; } = new HashSet<IMessageTypeConsumerInvokerSettings>();
 
     public ConsumerSettings ParentSettings => this;
     /// <summary>

--- a/src/SlimMessageBus.Host/Config/Fluent/ConsumerBuilder.cs
+++ b/src/SlimMessageBus.Host/Config/Fluent/ConsumerBuilder.cs
@@ -5,6 +5,7 @@ public class ConsumerBuilder<T> : AbstractConsumerBuilder
     public ConsumerBuilder(MessageBusSettings settings, Type messageType = null)
         : base(settings, messageType ?? typeof(T))
     {
+        ConsumerSettings.ConsumerMode = ConsumerMode.Consumer;
     }
 
     public ConsumerBuilder<T> Path(string path)
@@ -35,7 +36,6 @@ public class ConsumerBuilder<T> : AbstractConsumerBuilder
     public ConsumerBuilder<T> WithConsumer<TConsumer>()
         where TConsumer : class, IConsumer<T>
     {
-        ConsumerSettings.ConsumerMode = ConsumerMode.Consumer;
         ConsumerSettings.ConsumerType = typeof(TConsumer);
         ConsumerSettings.ConsumerMethod = (consumer, message) => ((IConsumer<T>)consumer).OnHandle((T)message);
 
@@ -98,7 +98,6 @@ public class ConsumerBuilder<T> : AbstractConsumerBuilder
     {
         if (consumerMethod == null) throw new ArgumentNullException(nameof(consumerMethod));
 
-        ConsumerSettings.ConsumerMode = ConsumerMode.Consumer;
         ConsumerSettings.ConsumerType = typeof(TConsumer);
         ConsumerSettings.ConsumerMethod = (consumer, message) => consumerMethod((TConsumer)consumer, (T)message);
 
@@ -135,7 +134,6 @@ public class ConsumerBuilder<T> : AbstractConsumerBuilder
 
         consumerMethodName ??= nameof(IConsumer<object>.OnHandle);
 
-        ConsumerSettings.ConsumerMode = ConsumerMode.Consumer;
         ConsumerSettings.ConsumerType = consumerType;
         SetupConsumerOnHandleMethod(ConsumerSettings, consumerMethodName);
 

--- a/src/SlimMessageBus.Host/Config/Fluent/HandlerBuilder.cs
+++ b/src/SlimMessageBus.Host/Config/Fluent/HandlerBuilder.cs
@@ -7,6 +7,7 @@ public class HandlerBuilder<TRequest, TResponse> : AbstractConsumerBuilder
     {
         if (settings == null) throw new ArgumentNullException(nameof(settings));
 
+        ConsumerSettings.ConsumerMode = ConsumerMode.RequestResponse;
         ConsumerSettings.ResponseType = responseType ?? typeof(TResponse);
     }
 
@@ -24,7 +25,7 @@ public class HandlerBuilder<TRequest, TResponse> : AbstractConsumerBuilder
     /// <returns></returns>
     public HandlerBuilder<TRequest, TResponse> Path(string path)
     {
-        var consumerSettingsExist = Settings.Consumers.Any(x => x.Path == path && x.ConsumerMode == ConsumerMode.RequestResponse);
+        var consumerSettingsExist = Settings.Consumers.Any(x => x.Path == path && x.ConsumerMode == ConsumerMode.RequestResponse && x != ConsumerSettings);
         Assert.IsFalse(consumerSettingsExist,
             () => new ConfigurationMessageBusException($"Attempted to configure request handler for topic/queue '{path}' when one was already configured. You can only have one request handler for a given topic/queue, otherwise which response would you send back?"));
 
@@ -61,7 +62,6 @@ public class HandlerBuilder<TRequest, TResponse> : AbstractConsumerBuilder
         Assert.IsNotNull(ConsumerSettings.ResponseType,
             () => new ConfigurationMessageBusException($"The {nameof(ConsumerSettings)}.{nameof(ConsumerSettings.ResponseType)} is not set"));
 
-        ConsumerSettings.ConsumerMode = ConsumerMode.RequestResponse;
         ConsumerSettings.ConsumerType = typeof(THandler);
         ConsumerSettings.ConsumerMethod = (consumer, message) => ((THandler)consumer).OnHandle((TRequest)message);
 
@@ -75,7 +75,6 @@ public class HandlerBuilder<TRequest, TResponse> : AbstractConsumerBuilder
         Assert.IsNotNull(ConsumerSettings.ResponseType,
             () => new ConfigurationMessageBusException($"The {nameof(ConsumerSettings)}.{nameof(ConsumerSettings.ResponseType)} is not set"));
 
-        ConsumerSettings.ConsumerMode = ConsumerMode.RequestResponse;
         ConsumerSettings.ConsumerType = handlerType;
         SetupConsumerOnHandleMethod(ConsumerSettings);
 

--- a/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/OutboxTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/OutboxTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace SlimMessageBus.Host.Outbox.DbContext.Test;
 
-using System.Collections.Concurrent;
 using System.Reflection;
 
 using Confluent.Kafka;

--- a/src/Tests/SlimMessageBus.Host.Test/Config/ConsumerBuilderTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Config/ConsumerBuilderTest.cs
@@ -12,7 +12,7 @@ public class ConsumerBuilderTest
     }
 
     [Fact]
-    public void Given_MessageType_When_Configured_Then_MessageType_ProperlySet()
+    public void Given_MessageType_When_Configured_Then_MessageType_ProperlySet_And_ConsumerTypeNull()
     {
         // arrange
 
@@ -20,6 +20,8 @@ public class ConsumerBuilderTest
         var subject = new ConsumerBuilder<SomeMessage>(messageBusSettings);
 
         // assert
+        subject.ConsumerSettings.ConsumerMode.Should().Be(ConsumerMode.Consumer);
+        subject.ConsumerSettings.ConsumerType.Should().BeNull();
         subject.ConsumerSettings.MessageType.Should().Be(typeof(SomeMessage));
     }
 

--- a/src/Tests/SlimMessageBus.Host.Test/Config/HandlerBuilderTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Config/HandlerBuilderTest.cs
@@ -4,22 +4,57 @@ using SlimMessageBus.Host.Config;
 
 public class HandlerBuilderTest
 {
+    private readonly MessageBusSettings messageBusSettings;
+
+    public HandlerBuilderTest()
+    {
+        messageBusSettings = new MessageBusSettings();
+    }
+
+    [Fact]
+    public void Given_RequestAndResposeType_When_Configured_Then_MessageType_And_ResponseType_And_DefaultHandlerTypeSet_ProperlySet()
+    {
+        // arrange
+
+        // act
+        var subject = new HandlerBuilder<SomeRequest, SomeResponse>(messageBusSettings);
+
+        // assert
+        subject.ConsumerSettings.ConsumerMode.Should().Be(ConsumerMode.RequestResponse);
+        subject.ConsumerSettings.ConsumerType.Should().BeNull();
+        subject.ConsumerSettings.MessageType.Should().Be(typeof(SomeRequest));
+        subject.ConsumerSettings.ResponseType.Should().Be(typeof(SomeResponse));
+    }
+
+    [Fact]
+    public void Given_Path_Set_When_Configured_Then_Path_ProperlySet()
+    {
+        // arrange
+        var path = "topic";
+
+        // act
+        var subject = new HandlerBuilder<SomeRequest, SomeResponse>(messageBusSettings)
+            .Path(path);
+
+        // assert
+        subject.ConsumerSettings.Path.Should().Be(path);
+        subject.ConsumerSettings.PathKind.Should().Be(PathKind.Topic);
+    }
+
     [Fact]
     public void BuildsProperSettings()
     {
         // arrange
         var path = "topic";
-        var settings = new MessageBusSettings();
 
         // act
-        var subject = new HandlerBuilder<SomeRequest, SomeResponse>(settings)
+        var subject = new HandlerBuilder<SomeRequest, SomeResponse>(messageBusSettings)
             .Topic(path)
             .Instances(3)
             .WithHandler<SomeRequestMessageHandler>();
 
         // assert
         subject.ConsumerSettings.MessageType.Should().Be(typeof(SomeRequest));
-        subject.MessageType.Should().Be(typeof(SomeRequest));
         subject.ConsumerSettings.Path.Should().Be(path);
         subject.ConsumerSettings.Instances.Should().Be(3);
         subject.ConsumerSettings.ConsumerType.Should().Be(typeof(SomeRequestMessageHandler));
@@ -34,6 +69,5 @@ public class HandlerBuilderTest
         consumerInvokerSettings.ConsumerType.Should().Be(typeof(SomeRequestMessageHandler));
         Func<Task> call = () => consumerInvokerSettings.ConsumerMethod(new SomeRequestMessageHandler(), new SomeRequest());
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(SomeRequest));
-
     }
 }

--- a/src/Tests/SlimMessageBus.Host.Test/Config/MessageBusBuilderTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Config/MessageBusBuilderTests.cs
@@ -12,19 +12,50 @@ public class MessageBusBuilderTests
     }
 
     [Fact]
+    public void When_Consume_Given_NoDeclaredConsumerType_Then_DefaultConsumerTypeSet()
+    {
+        // arrange
+        var subject = MessageBusBuilder.Create();
+
+        // act
+        subject.Consume<SomeMessage>(x => { });
+
+        // assert
+        subject.Settings.Consumers.Count.Should().Be(1);
+        subject.Settings.Consumers[0].MessageType.Should().Be(typeof(SomeMessage));
+        subject.Settings.Consumers[0].ConsumerType.Should().Be(typeof(IConsumer<SomeMessage>));
+    }
+
+    [Fact]
+    public void When_Handle_Given_NoDeclaredHandlerType_Then_DefaultHandlerTypeSet()
+    {
+        // arrange
+        var subject = MessageBusBuilder.Create();
+
+        // act
+        subject.Handle<SomeRequest, SomeResponse>(x => { });
+
+        // assert
+        subject.Settings.Consumers.Count.Should().Be(1);
+        subject.Settings.Consumers[0].MessageType.Should().Be(typeof(SomeRequest));
+        subject.Settings.Consumers[0].ResponseType.Should().Be(typeof(SomeResponse));
+        subject.Settings.Consumers[0].ConsumerType.Should().Be(typeof(IRequestHandler<SomeRequest, SomeResponse>));
+    }
+
+    [Fact]
     public void Given_OtherBuilder_When_CopyConstructorUsed_Then_AllStateIsCopied()
     {
         // arrange
-        var prototype = MessageBusBuilder.Create();
+        var subject = MessageBusBuilder.Create();
 
         // act
-        var copy = new DerivedMessageBusBuilder(prototype);
+        var copy = new DerivedMessageBusBuilder(subject);
 
         // assert
-        copy.Settings.Should().BeSameAs(prototype.Settings);
-        copy.Settings.Name.Should().BeSameAs(prototype.Settings.Name);
-        copy.Configurators.Should().BeSameAs(prototype.Configurators);
-        copy.ChildBuilders.Should().BeSameAs(prototype.ChildBuilders);
-        copy.BusFactory.Should().BeSameAs(prototype.BusFactory);
+        copy.Settings.Should().BeSameAs(subject.Settings);
+        copy.Settings.Name.Should().BeSameAs(subject.Settings.Name);
+        copy.Configurators.Should().BeSameAs(subject.Configurators);
+        copy.ChildBuilders.Should().BeSameAs(subject.ChildBuilders);
+        copy.BusFactory.Should().BeSameAs(subject.BusFactory);
     }
 }


### PR DESCRIPTION
We can assume the consumer type to `IConsumer<TMessage>` and hence avoid `.WithConsumer<SomeConsumer>()`  most of the time.

Before:

```cs
 services.AddSlimMessageBus((mbb, svp) =>
{
  mbb.Consume<CustomerCreatedEvent>(x => x
          .Topic(topic)
          .WithConsumer<CustomerCreatedEventConsumer>() // <------- this
          .SubscriptionName("sub");
  });
}, addConsumersFromAssembly: new[] { Assembly.GetExecutingAssembly() });
```

After:

```cs
 services.AddSlimMessageBus((mbb, svp) =>
{
  mbb.Consume<CustomerCreatedEvent>(x => x
          .Topic(topic)
          .SubscriptionName("sub");
  });
}, addConsumersFromAssembly: new[] { Assembly.GetExecutingAssembly() });
```

With this change, the `addConsumersFromAssembly` will register both `CustomerCreatedEventConsumer` and `IConsumer<CustomerCreatedEvent>` in the MSDI.

