### PR TITLE
[Host.Kafka] Kafka default message serializer

### DIFF
--- a/docs/provider_kafka.md
+++ b/docs/provider_kafka.md
@@ -125,7 +125,7 @@ SMB Kafka allows to set a provider (selector) that will assign the message key f
 
 ```cs
 // MessageBusBuilder mbb;
-mbb.    
+mbb    
    .Produce<MultiplyRequest>(x => 
    {
       x.DefaultTopic("topic1");
@@ -133,7 +133,6 @@ mbb.
       x.KeyProvider((request, topic) => Encoding.ASCII.GetBytes((request.Left + request.Right).ToString()));
    })
    .WithProviderKafka(new KafkaMessageBusSettings(kafkaBrokers))
-   .Build();
 ```
 
 The key must be a `byte[]`.
@@ -182,7 +181,7 @@ This could be useful to extract the message's offset or partition.
 SMB uses headers to pass additional metadata information with the message. This includes the `MessageType` (of type `string`) or in the case of request/response messages the `RequestId` (of type `string`), `ReplyTo` (of type `string`) and `Expires` (of type `long`).
 
 The Kafka message header values are natively binary (`byte[]`) in the underlying .NET client, as a result SMB needs to serialize the header values.
-By default the same serializer is used to serialize header values as is being used for the message serialization.
+By default the [DefaultKafkaHeaderSerializer](../src/SlimMessageBus.Host.Kafka/DefaultKafkaHeaderSerializer.cs) is used to serialize header values.
 If you need to specify a different serializer provide a specfic `IMessageSerializer` implementation (custom or one of the available serialization plugins):
 
 ```cs
@@ -190,11 +189,11 @@ If you need to specify a different serializer provide a specfic `IMessageSeriali
 mbb.    
    .WithProviderKafka(new KafkaMessageBusSettings(kafkaBrokers)
    {
-      HeaderSerializer = new JsonMessageSerializer() // specify a different header values serializer
+      HeaderSerializer = new DefaultKafkaHeaderSerializer() // specify a different header values serializer
    });
 ```
 
-> By default for header serialization (if not specified) SMB Kafka uses the same serializer that was set for the bus.
+> Since version 2.0.0, uses the [DefaultKafkaHeaderSerializer](../src/SlimMessageBus.Host.Kafka/DefaultKafkaHeaderSerializer.cs) serializer which converts the passed values into string. Prior version 2.0.0, by default the same serializer for the bus was used to also serialize message header values.
 
 ## Deployment
 

--- a/src/SlimMessageBus.Host.Kafka/Configs/BuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Kafka/Configs/BuilderExtensions.cs
@@ -1,7 +1,5 @@
 ﻿namespace SlimMessageBus.Host.Kafka;
 
-using SlimMessageBus.Host.Config;
-
 public static class BuilderExtensions
 {
     /// <summary>

--- a/src/SlimMessageBus.Host.Kafka/Configs/KafkaMessageBusBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Kafka/Configs/KafkaMessageBusBuilderExtensions.cs
@@ -1,7 +1,5 @@
 namespace SlimMessageBus.Host.Kafka;
 
-using SlimMessageBus.Host.Config;
-
 public static class KafkaMessageBusBuilderExtensions
 {
     public static MessageBusBuilder WithProviderKafka(this MessageBusBuilder mbb, KafkaMessageBusSettings kafkaSettings)

--- a/src/SlimMessageBus.Host.Kafka/Configs/KafkaMessageBusSettings.cs
+++ b/src/SlimMessageBus.Host.Kafka/Configs/KafkaMessageBusSettings.cs
@@ -1,9 +1,11 @@
 namespace SlimMessageBus.Host.Kafka;
 
 using Confluent.Kafka;
-using ProducerBuilder = Confluent.Kafka.ProducerBuilder<byte[], byte[]>;
-using ConsumerBuilder = Confluent.Kafka.ConsumerBuilder<Confluent.Kafka.Ignore, byte[]>;
+
 using SlimMessageBus.Host.Serialization;
+
+using ConsumerBuilder = Confluent.Kafka.ConsumerBuilder<Confluent.Kafka.Ignore, byte[]>;
+using ProducerBuilder = Confluent.Kafka.ProducerBuilder<byte[], byte[]>;
 
 public class KafkaMessageBusSettings
 {
@@ -35,7 +37,7 @@ public class KafkaMessageBusSettings
     public TimeSpan ConsumerPollRetryInterval { get; set; }
 
     /// <summary>
-    /// Serializer used to serialize Kafka message header values. If not specified the default serializer will be used (setup as part of the bus config).
+    /// Serializer used to serialize Kafka message header values. If not specified the default serializer will be used (setup as part of the bus config). By default the <see cref="DefaultKafkaHeaderSerializer"/> is used.
     /// </summary>
     public IMessageSerializer HeaderSerializer { get; set; }
 
@@ -54,5 +56,6 @@ public class KafkaMessageBusSettings
         ConsumerConfig = (config) => { };
         ConsumerBuilderFactory = (config) => new ConsumerBuilder<Ignore, byte[]>(config);
         ConsumerPollRetryInterval = TimeSpan.FromSeconds(2);
+        HeaderSerializer = new DefaultKafkaHeaderSerializer();
     }
 }

--- a/src/SlimMessageBus.Host.Kafka/Configs/KafkaProducerBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Kafka/Configs/KafkaProducerBuilderExtensions.cs
@@ -1,7 +1,5 @@
 ﻿namespace SlimMessageBus.Host.Kafka;
 
-using SlimMessageBus.Host.Config;
-
 public static class KafkaProducerBuilderExtensions
 {
     /// <summary>

--- a/src/SlimMessageBus.Host.Kafka/Configs/KafkaProducerSettingsExtensions.cs
+++ b/src/SlimMessageBus.Host.Kafka/Configs/KafkaProducerSettingsExtensions.cs
@@ -1,7 +1,5 @@
 ﻿namespace SlimMessageBus.Host.Kafka;
 
-using SlimMessageBus.Host.Config;
-
 public static class KafkaProducerSettingsExtensions
 {
     internal const string KeyProviderKey = "Kafka_KeyProvider";

--- a/src/SlimMessageBus.Host.Kafka/Configs/SettingsExtensions.cs
+++ b/src/SlimMessageBus.Host.Kafka/Configs/SettingsExtensions.cs
@@ -1,7 +1,5 @@
 ﻿namespace SlimMessageBus.Host.Kafka;
 
-using SlimMessageBus.Host.Config;
-
 public static class SettingsExtensions
 {
     private const string GroupKey = "Group";

--- a/src/SlimMessageBus.Host.Kafka/Consumer/IKafkaCommitController.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/IKafkaCommitController.cs
@@ -1,7 +1,5 @@
 namespace SlimMessageBus.Host.Kafka;
 
-using Confluent.Kafka;
-
 public interface IKafkaCommitController
 {
     void Commit(TopicPartitionOffset offset);

--- a/src/SlimMessageBus.Host.Kafka/Consumer/KafkaExtensions.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/KafkaExtensions.cs
@@ -1,8 +1,8 @@
 ﻿namespace SlimMessageBus.Host.Kafka;
 
-using Confluent.Kafka;
-using SlimMessageBus.Host.Serialization;
 using System.Diagnostics.CodeAnalysis;
+
+using SlimMessageBus.Host.Serialization;
 
 public static class KafkaExtensions
 {

--- a/src/SlimMessageBus.Host.Kafka/Consumer/KafkaGroupConsumer.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/KafkaGroupConsumer.cs
@@ -2,12 +2,10 @@ namespace SlimMessageBus.Host.Kafka;
 
 using System.Diagnostics.CodeAnalysis;
 
-using Confluent.Kafka;
-
 using SlimMessageBus.Host.Collections;
 
-using ConsumeResult = Confluent.Kafka.ConsumeResult<Confluent.Kafka.Ignore, byte[]>;
-using IConsumer = Confluent.Kafka.IConsumer<Confluent.Kafka.Ignore, byte[]>;
+using ConsumeResult = ConsumeResult<Ignore, byte[]>;
+using IConsumer = IConsumer<Ignore, byte[]>;
 
 public class KafkaGroupConsumer : IAsyncDisposable, IKafkaCommitController
 {

--- a/src/SlimMessageBus.Host.Kafka/Consumer/KafkaPartitionConsumer.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/KafkaPartitionConsumer.cs
@@ -1,14 +1,10 @@
 ﻿namespace SlimMessageBus.Host.Kafka;
 
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 
-using Confluent.Kafka;
-
-using SlimMessageBus.Host.Config;
 using SlimMessageBus.Host.Serialization;
 
-using ConsumeResult = Confluent.Kafka.ConsumeResult<Confluent.Kafka.Ignore, byte[]>;
+using ConsumeResult = ConsumeResult<Ignore, byte[]>;
 
 public abstract class KafkaPartitionConsumer : IKafkaPartitionConsumer
 {
@@ -99,7 +95,7 @@ public abstract class KafkaPartitionConsumer : IKafkaPartitionConsumer
         {
             return;
         }
-        
+
         try
         {
             _lastOffset = message.TopicPartitionOffset;

--- a/src/SlimMessageBus.Host.Kafka/Consumer/KafkaPartitionConsumerForConsumers.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/KafkaPartitionConsumerForConsumers.cs
@@ -1,10 +1,10 @@
 namespace SlimMessageBus.Host.Kafka;
 
 using System.Diagnostics.CodeAnalysis;
-using Confluent.Kafka;
-using SlimMessageBus.Host.Config;
+
 using SlimMessageBus.Host.Serialization;
-using ConsumeResult = Confluent.Kafka.ConsumeResult<Confluent.Kafka.Ignore, byte[]>;
+
+using ConsumeResult = ConsumeResult<Ignore, byte[]>;
 
 /// <summary>
 /// Processor for regular consumers. 

--- a/src/SlimMessageBus.Host.Kafka/Consumer/KafkaPartitionConsumerForResponses.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/KafkaPartitionConsumerForResponses.cs
@@ -1,9 +1,7 @@
 namespace SlimMessageBus.Host.Kafka;
 
-using Confluent.Kafka;
-using SlimMessageBus.Host.Config;
 using SlimMessageBus.Host.Serialization;
-using ConsumeResult = Confluent.Kafka.ConsumeResult<Confluent.Kafka.Ignore, byte[]>;
+using ConsumeResult = ConsumeResult<Ignore, byte[]>;
 
 /// <summary>
 /// Processor for incomming response messages in the request-response patterns. 

--- a/src/SlimMessageBus.Host.Kafka/DefaultKafkaHeaderSerializer.cs
+++ b/src/SlimMessageBus.Host.Kafka/DefaultKafkaHeaderSerializer.cs
@@ -1,0 +1,62 @@
+﻿namespace SlimMessageBus.Host.Kafka;
+
+using System.Globalization;
+using System.Text;
+
+/// <summary>
+/// Serializes the headers values by doing a Convert.ToString(value, CultureInfo.InvariantCulture) on them.
+/// </summary>
+public class DefaultKafkaHeaderSerializer : IMessageSerializer
+{
+    private readonly Encoding _encoding;
+    private readonly bool _inferType;
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="encoding"></param>
+    /// <param name="inferType">Should the string attempted to be parsed against the common primitive types.</param>
+    public DefaultKafkaHeaderSerializer(Encoding encoding = null, bool inferType = false)
+    {
+        _encoding = encoding ?? Encoding.UTF8;
+        _inferType = inferType;
+    }
+
+    #region Implementation of IMessageSerializer
+
+    public byte[] Serialize(Type t, object message)
+    {
+        if (message == null) return null;
+        var payload = _encoding.GetBytes(Convert.ToString(message, CultureInfo.InvariantCulture));
+        return payload;
+    }
+
+    public object Deserialize(Type t, byte[] payload)
+    {
+        if (payload == null) return null;
+
+        var str = _encoding.GetString(payload);
+        if (_inferType)
+        {
+            if (long.TryParse(str, out var valInt))
+            {
+                return valInt;
+            }
+            if (bool.TryParse(str, out var valBool))
+            {
+                return valBool;
+            }
+            if (Guid.TryParse(str, out var valGuid))
+            {
+                return valGuid;
+            }
+            if (decimal.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out var valDecimal))
+            {
+                return valDecimal;
+            }
+        }
+        return str;
+    }
+
+    #endregion
+}

--- a/src/SlimMessageBus.Host.Kafka/GlobalUsings.cs
+++ b/src/SlimMessageBus.Host.Kafka/GlobalUsings.cs
@@ -1,1 +1,7 @@
-﻿global using Microsoft.Extensions.Logging;
+﻿global using Confluent.Kafka;
+
+global using Microsoft.Extensions.Logging;
+
+global using SlimMessageBus.Host.Config;
+global using SlimMessageBus.Host.Serialization;
+

--- a/src/SlimMessageBus.Host.Kafka/KafkaMessageBus.cs
+++ b/src/SlimMessageBus.Host.Kafka/KafkaMessageBus.cs
@@ -1,11 +1,11 @@
 namespace SlimMessageBus.Host.Kafka;
 
-using Confluent.Kafka;
-using SlimMessageBus.Host.Config;
-using Message = Confluent.Kafka.Message<byte[], byte[]>;
-using IProducer = Confluent.Kafka.IProducer<byte[], byte[]>;
 using System.Diagnostics.CodeAnalysis;
-using SlimMessageBus.Host.Serialization;
+
+using Confluent.Kafka;
+
+using IProducer = Confluent.Kafka.IProducer<byte[], byte[]>;
+using Message = Confluent.Kafka.Message<byte[], byte[]>;
 
 /// <summary>
 /// <see cref="IMessageBus"/> implementation for Apache Kafka.

--- a/src/SlimMessageBus.Host/RequestResponse/MessageHeaderExtensions.cs
+++ b/src/SlimMessageBus.Host/RequestResponse/MessageHeaderExtensions.cs
@@ -36,7 +36,7 @@ public static class MessageHeaderExtensions
 
     public static bool TryGetHeader(this IReadOnlyDictionary<string, object> headers, string header, out string value)
     {
-        if (headers.TryGetValue(header, out object objValue))
+        if (headers.TryGetValue(header, out var objValue))
         {
             value = (string)objValue;
             return true;
@@ -47,7 +47,7 @@ public static class MessageHeaderExtensions
 
     public static bool TryGetHeader(this IDictionary<string, object> headers, string header, out string value)
     {
-        if (headers.TryGetValue(header, out object objValue))
+        if (headers.TryGetValue(header, out var objValue))
         {
             value = (string)objValue;
             return true;
@@ -60,9 +60,12 @@ public static class MessageHeaderExtensions
     {
         if (header != null && headers.TryGetValue(header, out var dtObj))
         {
-            var dtLong = (long)dtObj;
-            dt = DateTimeOffset.FromFileTime(dtLong);
-            return true;
+            var dtVal = TryGetDateTimeOffset(dtObj);
+            if (dtVal != null)
+            {
+                dt = dtVal.Value;
+                return true;
+            }
         }
         dt = default;
         return false;
@@ -72,9 +75,12 @@ public static class MessageHeaderExtensions
     {
         if (header != null && headers.TryGetValue(header, out var dtObj))
         {
-            var dtLong = (long)dtObj;
-            dt = DateTimeOffset.FromFileTime(dtLong);
-            return true;
+            var dtVal = TryGetDateTimeOffset(dtObj);
+            if (dtVal != null)
+            {
+                dt = dtVal.Value;
+                return true;
+            }
         }
         dt = default;
         return false;
@@ -100,5 +106,14 @@ public static class MessageHeaderExtensions
         }
         dt = null;
         return false;
+    }
+
+    private static DateTimeOffset? TryGetDateTimeOffset(object value)
+    {
+        if (value is long dtLong || (value is string dtString && long.TryParse(dtString, out dtLong)))
+        {
+            return DateTimeOffset.FromFileTime(dtLong);
+        }
+        return null;
     }
 }

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/DefaultKafkaHeaderSerializerTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/DefaultKafkaHeaderSerializerTest.cs
@@ -1,0 +1,38 @@
+﻿namespace SlimMessageBus.Host.Kafka.Test;
+
+public class DefaultKafkaHeaderSerializerTest
+{
+    [Theory]
+    [InlineData(null, null, false)]
+    [InlineData("abc", "abc", false)]
+    [InlineData(123, "123", false)]
+    [InlineData(123, 123L, true)]
+    [InlineData(123.5, "123.5", false)]
+    [InlineData(123.5, 123.5, true)]
+    [InlineData(true, "True", false)]
+    [InlineData(true, true, true)]
+    public void Test(object inValue, object outValue, bool inferType)
+    {
+        // arrange
+        var subject = new DefaultKafkaHeaderSerializer(inferType: inferType);
+
+        // act
+        var payload = subject.Serialize(typeof(object), inValue);
+        var actualValue = subject.Deserialize(typeof(object), payload);
+
+        // assert
+        if (inValue is null)
+        {
+            actualValue.Should().BeNull();
+        }
+        else
+        {
+            actualValue.Should().NotBeNull();
+            if (!inferType)
+            {
+                actualValue.Should().BeOfType<string>();
+            }
+            actualValue.Should().Be(outValue);
+        }
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/GlobalUsings.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/GlobalUsings.cs
@@ -1,6 +1,15 @@
-﻿global using Xunit;
-global using Xunit.Abstractions;
+﻿global using Confluent.Kafka;
+
 global using FluentAssertions;
-global using Moq;
+
 global using Microsoft.Extensions.Logging;
+
+global using Moq;
+
 global using SecretStore;
+
+global using SlimMessageBus.Host.Config;
+global using SlimMessageBus.Host.Serialization;
+
+global using Xunit;
+global using Xunit.Abstractions;

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/KafkaMessageBusTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/KafkaMessageBusTest.cs
@@ -1,10 +1,5 @@
 ﻿namespace SlimMessageBus.Host.Kafka.Test;
 
-using Confluent.Kafka;
-
-using SlimMessageBus.Host.Config;
-using SlimMessageBus.Host.Serialization;
-
 public class KafkaMessageBusTest : IDisposable
 {
     private MessageBusSettings MbSettings { get; }


### PR DESCRIPTION
It's better to have a simple serializer for Kafka header values that are set up by default regardless of the chosen message bus serializer.  The proposed serializer converts all the supplied values to string, and the UTF8 encoding is used by default to produce byte[] which the underlying Kafka client requires.

See #155 