### PR TITLE
[Host.AsyncApi] Exclude Memory named bus by default

### DIFF
--- a/src/SlimMessageBus.Host.AsyncApi/MessageBusBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.AsyncApi/MessageBusBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿namespace SlimMessageBus.Host.AsyncApi;
+
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 using Saunter.Generation;
@@ -10,9 +11,13 @@ public static class MessageBusBuilderExtensions
     /// </summary>
     /// <remarks>This needs to be run before the .AddAsyncApiSchemaGeneration() from Saunter</remarks>
     /// <param name="mbb"></param>
+    /// <param name="busFilter">Provides a filter method to exclude or include a (child) bus from AsyncAPI document generation. When not provided will filter out bus named Memory</param>
     /// <returns></returns>
-    public static MessageBusBuilder AddAsyncApiDocumentGenerator(this MessageBusBuilder mbb)
+    public static MessageBusBuilder AddAsyncApiDocumentGenerator(this MessageBusBuilder mbb, Func<MessageBusSettings, bool>? busFilter = null)
     {
+        mbb.Settings.Properties[BusFilter] = busFilter 
+            ?? (x => x.Name != "Memory");
+        
         mbb.PostConfigurationActions.Add(services =>
         {
             services.TryAddTransient<IDocumentGenerator, MessageBusDocumentGenerator>();
@@ -20,4 +25,6 @@ public static class MessageBusBuilderExtensions
 
         return mbb;
     }
+
+    internal const string BusFilter = "AsyncAPI_BusFilter";
 }

--- a/src/SlimMessageBus.Host.AsyncApi/MessageBusDocumentGenerator.cs
+++ b/src/SlimMessageBus.Host.AsyncApi/MessageBusDocumentGenerator.cs
@@ -39,6 +39,8 @@ public class MessageBusDocumentGenerator : IDocumentGenerator
 
         var generator = new JsonSchemaGenerator(options.SchemaOptions);
 
+        var busFilter = _busSettings.GetOrDefault<Func<MessageBusSettings, bool>?>(MessageBusBuilderExtensions.BusFilter, null);
+
         // ToDo: implement
         var serverByBusSettings = new Dictionary<MessageBusSettings, NamedServer>
         {
@@ -46,7 +48,10 @@ public class MessageBusDocumentGenerator : IDocumentGenerator
         };
         foreach (var childMessageBusSettings in _busSettings.Children)
         {
-            serverByBusSettings.Add(childMessageBusSettings, new(childMessageBusSettings.Name, new Server("kafka://kafka.cluster", "kafka")));
+            if (busFilter == null || busFilter(childMessageBusSettings))
+            {
+                serverByBusSettings.Add(childMessageBusSettings, new(childMessageBusSettings.Name, new Server("kafka://kafka.cluster", "kafka")));
+            }
         }
 
         foreach (var (messageBusSettings, namedServer) in serverByBusSettings)


### PR DESCRIPTION
On the AsyncApi plugin:
- exclude bus named `Memory` by default
- ability to provide additional filter method to `AddAsyncApiDocumentGenerator()`