### PR TITLE
[Host.AzureServiceBus] Add option for replacing already defined rules in ASB subscription

### DIFF
--- a/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusTopologyService.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusTopologyService.cs
@@ -1,5 +1,7 @@
 ﻿namespace SlimMessageBus.Host.AzureServiceBus;
 
+using Azure;
+
 public class ServiceBusTopologyService
 {
     private readonly ILogger<ServiceBusTopologyService> logger;
@@ -180,6 +182,19 @@ public class ServiceBusTopologyService
                                     {
                                         // Note: for a newly created subscription, ASB creates a default filter automatically, we need to remove it and let the user defined rules take over
                                         await adminClient.DeleteRuleAsync(path, subscriptionName, "$Default");
+                                    }
+
+                                    if (topologyProvisioning.CanConsumerReplaceSubscriptionFilters)
+                                    {
+                                        // Note: remove already defined rules for existing subscription
+                                        var removeRuleTasks = new List<Task<Response>>();
+                                        await foreach (var rulesPage in adminClient.GetRulesAsync(path, subscriptionName).AsPages())
+                                        {
+                                            removeRuleTasks
+                                                .AddRange(rulesPage.Values.Where(rule => !filters.Any(filter => filter.Name == rule.Name))
+                                                .Select(rule => adminClient.DeleteRuleAsync(path, subscriptionName, rule.Name)));
+                                        }
+                                        await Task.WhenAll(removeRuleTasks);
                                     }
 
                                     var tasks = filters.Select(filter => TryCreateRule(path, subscriptionName, filter.Name, options =>

--- a/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusTopologyService.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusTopologyService.cs
@@ -38,11 +38,11 @@ public class ServiceBusTopologyService
         }
     }
 
-    private Task<Response> SwallowExceptionIfMessagingEntityNotFound(Func<Task<Response>> task)
+    private async Task<Response> SwallowExceptionIfMessagingEntityNotFound(Func<Task<Response>> task)
     {
         try
         {
-            return task();
+            return await task();
         }
         catch (ServiceBusException e) when (e.Reason == ServiceBusFailureReason.MessagingEntityNotFound)
         {
@@ -206,9 +206,9 @@ public class ServiceBusTopologyService
                                             removeRuleTasks
                                                 .AddRange(rulesPage.Values
                                                     .Where(rule => !filters.Any(filter => filter.Name == rule.Name))
-                                                    .Select(rule => SwallowExceptionIfMessagingEntityNotFound(() =>
+                                                    .Select(rule => SwallowExceptionIfMessagingEntityNotFound(() => 
                                                         adminClient.DeleteRuleAsync(path, subscriptionName, rule.Name)))
-                                                    .Where(task => task != null));
+                                                );
                                         }
                                         await Task.WhenAll(removeRuleTasks);
                                     }

--- a/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusTopologySettings.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusTopologySettings.cs
@@ -31,6 +31,10 @@ public class ServiceBusTopologySettings
     /// </summary>
     public bool CanConsumerCreateSubscriptionFilter { get; set; } = true;
     /// <summary>
+    /// A filter that allows (or not) for declared consumers to replace already defined filters. False by default.
+    /// </summary>
+    public bool CanConsumerReplaceSubscriptionFilters { get; set; } = false;
+    /// <summary>
     /// Default configuration to be applied when a queue needs to be created (<see cref="CreateQueueOptions"/>).
     /// </summary>
     public Action<CreateQueueOptions> CreateQueueOptions { get; set; }


### PR DESCRIPTION
This PR adds option `CanConsumerReplaceSubscriptionFilters` which is set to `false` by default. 
If it's `true`, then whenever any rules are already defined for ASB subscription, then SMB will replace them with newly defined ones.

Context: I observed an issue, if a subscription was defined without the rules, and after some time I decided to add some, then subscription had two rules:

- `$Default`
- and newly added rule

Expected behaviour is to remove the default one, once new rules are declared.

How to use this behaviour: set `ServiceBusTopologySettings`'s `CanConsumerReplaceSubscriptionFilters` flag to true.
Once you do it, if you defined any set of rules, they will override already exisiting ones.

NOTE: It compares already existing rules by name, so let say: if there is a rule with name `rule` and then you define new rule with name `rule` but different condition, it won't override it. To be discussed this should work like this, or rather it should compare condition as well.

Docs not yet updated.

Signed-off-by: Paweł Mazurek [ziurek0@gmail.com](mailto:ziurek0@gmail.com)

