### PR TITLE
[Host] Ability to provide lifetime for .AddServicesFromAssembly() for consumers and interceptors

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -566,24 +566,39 @@ services.AddSlimMessageBus(mbb =>
 Consider the following example:
 
 ```cs
-// Given a consumer that is found:
-public class SomeMessageConsumer : IConsumer<SomeMessage>
-{
-}
-
+// Given a consumer that is found in the executing assembly:
+public class SomeMessageConsumer : IConsumer<SomeMessage> { }
+ 
+// When configuring the bus:
 services.AddSlimMessageBus(mbb =>
 {
   // When auto-registration is used:
   mbb.AddConsumersFromAssembly(Assembly.GetExecutingAssembly());
 };
 
+// Then the .AddConsumersFromAssembly() will result in an equivalent services registration (if it were done manually):
+// services.TryAddTransient<SomeMessageConsumer>();
+// services.TryAddTransient<IConsumer<SomeMessage>>(svp => svp.GetRequiredService<SomeMessageConsumer>());
 ```
 
-This will result in an equivalent services registration:
+There is also an option to override the default lifetime of the discovered types (since v2.1.5):
 
 ```cs
-services.TryAddTransient<SomeMessageConsumer>();
-services.TryAddTransient<IConsumer<SomeMessage>, SomeMessageConsumer>();
+services.AddSlimMessageBus(mbb =>
+{
+  // Register the found types as Scoped lifetime in MSDI
+  mbb.AddConsumersFromAssembly(Assembly.GetExecutingAssembly(), consumerLifetime: ServiceLifetime.Scoped);
+};
+```
+
+There is also an option to provide a type filter predicate. This might be helpful to scan only for types in a specified namespace inside of the assembly:
+
+```cs
+services.AddSlimMessageBus(mbb =>
+{
+  // Register the found types that contain DomainEventHandlers in the namespacce
+  mbb.AddConsumersFromAssembly(Assembly.GetExecutingAssembly(), filter: (type) => type.Namespace.Contains("DomainEventHandlers"));
+};
 ```
 
 ### ASP.Net Core

--- a/src/Host.Transport.Properties.xml
+++ b/src/Host.Transport.Properties.xml
@@ -4,7 +4,7 @@
 	<Import Project="Common.Properties.xml" />
 
 	<PropertyGroup>
-    <Version>2.1.4</Version>
+    <Version>2.1.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/SlimMessageBus.Host.Configuration/Discovery/ReflectionDiscoveryScanner.cs
+++ b/src/SlimMessageBus.Host.Configuration/Discovery/ReflectionDiscoveryScanner.cs
@@ -67,10 +67,11 @@ public class ReflectionDiscoveryScanner
         typeof(IRequestHandler<>)
     };
 
-    public IReadOnlyCollection<DiscoveryProspectType> GetInterceptorTypes()
+    public IReadOnlyCollection<DiscoveryProspectType> GetInterceptorTypes(Func<Type, bool> filterPredicate = null)
     {
         var foundTypes = ProspectTypes
             .Where(x => x.InterfaceType.IsGenericType && GenericTypesInterceptors.Contains(x.InterfaceType.GetGenericTypeDefinition()))
+            .Where(x => filterPredicate == null || filterPredicate(x.Type))
             .ToList();
 
         return foundTypes;

--- a/src/Tests/SlimMessageBus.Host.Memory.Test/MemoryMessageBusBuilderTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Memory.Test/MemoryMessageBusBuilderTests.cs
@@ -21,8 +21,9 @@ public class MemoryMessageBusBuilderTests
         // arrange
 
         // act
+        var whitelistNames = new[] { "Ping", "Echo", "Some", "Generic" };
         subject.AutoDeclareFrom(Assembly.GetExecutingAssembly(),
-            consumerTypeFilter: (consumerType) => consumerType.Name.Contains("Ping") || consumerType.Name.Contains("Echo") || consumerType.Name.Contains("Some")); // include specific consumers only
+            consumerTypeFilter: (consumerType) => whitelistNames.Any(name => consumerType.Name.Contains(name))); // include specific consumers only
 
         // assert
 

--- a/src/Tests/SlimMessageBus.Host.Memory.Test/MemoryMessageBusTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Memory.Test/MemoryMessageBusTests.cs
@@ -434,6 +434,11 @@ public class SomeMessageAConsumer : IConsumer<SomeMessageA>, IDisposable
     public virtual Task OnHandle(SomeMessageA messageA) => Task.CompletedTask;
 }
 
+public class GenericConsumer<T> : IConsumer<T>
+{
+    public Task OnHandle(T message) => Task.CompletedTask;
+}
+
 public class SomeMessageAConsumer2 : IConsumer<SomeMessageA>
 {
     public virtual Task OnHandle(SomeMessageA messageA) => Task.CompletedTask;

--- a/src/Tests/SlimMessageBus.Host.Test/DependencyResolver/ServiceCollectionExtensionsTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/DependencyResolver/ServiceCollectionExtensionsTest.cs
@@ -117,7 +117,7 @@ public class ServiceCollectionExtensionsTest
         {
             mbb.AddChildBus("bus1", mbb =>
             {
-                mbb.AddServicesFromAssemblyContaining<ServiceCollectionExtensionsTest>(x => x.Name == nameof(SomeMessageConsumer));
+                mbb.AddServicesFromAssemblyContaining<ServiceCollectionExtensionsTest>(x => x.Name == nameof(SomeMessageConsumer), consumerLifetime: ServiceLifetime.Scoped);
             });
         });
 
@@ -125,14 +125,14 @@ public class ServiceCollectionExtensionsTest
         {
             mbb.AddChildBus("bus2", mbb =>
             {
-                mbb.AddServicesFromAssemblyContaining<ServiceCollectionExtensionsTest>(x => x.Name == nameof(SomeMessageConsumer));
+                mbb.AddServicesFromAssemblyContaining<ServiceCollectionExtensionsTest>(x => x.Name == nameof(SomeMessageConsumer), consumerLifetime: ServiceLifetime.Transient);
             });
         });
 
         // assert
         _services.Count(x => x.ServiceType == typeof(SomeMessageConsumer)).Should().Be(1);
         _services.Count(x => x.ServiceType == typeof(IConsumer<SomeMessage>)).Should().Be(1);
-        _services.Should().Contain(x => x.ServiceType == typeof(SomeMessageConsumer) && x.ImplementationType == typeof(SomeMessageConsumer) && x.Lifetime == ServiceLifetime.Transient);
-        _services.Should().Contain(x => x.ServiceType == typeof(IConsumer<SomeMessage>) && x.ImplementationType == typeof(SomeMessageConsumer) && x.Lifetime == ServiceLifetime.Transient);
+        _services.Should().Contain(x => x.ServiceType == typeof(SomeMessageConsumer) && x.ImplementationType == typeof(SomeMessageConsumer) && x.Lifetime == ServiceLifetime.Scoped);
+        _services.Should().Contain(x => x.ServiceType == typeof(IConsumer<SomeMessage>) && x.ImplementationFactory != null && x.Lifetime == ServiceLifetime.Scoped);
     }
 }


### PR DESCRIPTION
We can now provide the lifetime for the discovered consumers and interceptors.
Before found types were registered as transient only.