### PR TITLE
Fix runtime dependency issue

### DIFF
--- a/src/Host.Transport.Properties.xml
+++ b/src/Host.Transport.Properties.xml
@@ -4,7 +4,7 @@
 	<Import Project="Common.Properties.xml" />
 
 	<PropertyGroup>
-    <Version>2.1.5</Version>
+    <Version>2.1.6</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
+++ b/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <Description>Core configuration interfaces of SlimMessageBus</Description>
     <PackageTags>SlimMessageBus</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
The 2.1.5 version experiences the following runtime error:

```
System.MissingMethodException: Method not found: 'System.Collections.Generic.IReadOnlyCollection`1<SlimMessageBus.Host.DiscoveryProspectType> SlimMessageBus.Host.ReflectionDiscoveryScanner.GetInterceptorTypes(System.Func`2<System.Type,Boolean>)'.
   at SlimMessageBus.Host.ServiceCollectionExtensions.AddServicesFromAssembly(MessageBusBuilder mbb, Assembly assembly, Func`2 filter, ServiceLifetime consumerLifetime, ServiceLifetime interceptorLifetime)
   at SlimMessageBus.Host.ServiceCollectionExtensions.AddServicesFromAssemblyContaining[T](MessageBusBuilder mbb, Func`2 filter, ServiceLifetime consumerLifetime, ServiceLifetime interceptorLifetime)
```

The fix is to upgrade the SlimMessageBus.Host.Configuration version.