### PR TITLE
[Host.Memory] Preserve user's exception's stack details

### DIFF
--- a/src/SlimMessageBus.Host.Memory/MemoryMessageBus.cs
+++ b/src/SlimMessageBus.Host.Memory/MemoryMessageBus.cs
@@ -1,5 +1,7 @@
 ﻿namespace SlimMessageBus.Host.Memory;
 
+using System.Runtime.ExceptionServices;
+
 /// <summary>
 /// In-memory message bus <see cref="IMessageBus"/> implementation to use for in process message passing.
 /// </summary>
@@ -106,8 +108,9 @@ public class MemoryMessageBus : MessageBusBase<MemoryMessageBusSettings>
         var (exception, _, response, _) = await messageProcessor.ProcessMessage(transportMessage, messageHeadersReadOnly, cancellationToken, currentServiceProvider);
         if (exception != null)
         {
+            
             // We want to pass the same exception to the sender as it happened in the handler/consumer
-            throw exception;
+            ExceptionDispatchInfo.Capture(exception).Throw();
         }
 
         return (TResponseMessage)response;


### PR DESCRIPTION
[Host.Memory] Preserve user's exception's stack details

This is a bug-fix for Host.Memory package.

We have encountered with weird behavior when handling exceptions thrown on consumer side. Essentially exceptions are captured and re-thrown later on and loosing all stack details. In the end it is extremely difficult to trace back the problem if some more generic exception was thrown (e.g. ArgumentNullException from some .net libraries). This PR fixes that problem.

Details about throwing exceptions:

`throw exception;` re-throws exception disregarding existing stack details
`throw;` re-throws exception and keeps existing stack details, however works only in catch block
In this case to preserve exception's details we need to re-throw exception using `ExceptionDispatchInfo` class provided by .net

This is part of [best practices for exceptions](https://learn.microsoft.com/en-us/dotnet/standard/exceptions/best-practices-for-exceptions#capture-exceptions-to-rethrow-later)
