### PR TITLE
 [Host.Hybrid] SlimMessageBus.Host.ConfigurationMessageBusException: Could not find any bus that produces the message type

### DIFF
--- a/src/Host.Plugin.Properties.xml
+++ b/src/Host.Plugin.Properties.xml
@@ -5,7 +5,7 @@
 
 	<PropertyGroup>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
-    <Version>2.2.0-rc2</Version>
+    <Version>2.2.0-rc3</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host/Hybrid/HybridMessageBusSettings.cs
+++ b/src/SlimMessageBus.Host/Hybrid/HybridMessageBusSettings.cs
@@ -5,10 +5,33 @@ public class HybridMessageBusSettings
     /// <summary>
     /// When there are multiple matching bus for a publish message type, defines the mode of execution.
     /// </summary>
+    /// <remarks>The default is <see cref="PublishExecutionMode.Sequential"/>.</remarks>
     public PublishExecutionMode PublishExecutionMode { get; set; } = PublishExecutionMode.Sequential;
+
+    /// <summary>
+    /// When a message type is being produced that has no matching child bus that can produce such a message, defines the mode of execution.
+    /// </summary>
+    /// <remarks>The default is <see cref="UndeclaredMessageTypeMode.RaiseOneTimeLog"/>.</remarks>
+    public UndeclaredMessageTypeMode UndeclaredMessageTypeMode { get; set; } = UndeclaredMessageTypeMode.RaiseOneTimeLog;
 }
 
-public enum PublishExecutionMode : int
+public enum UndeclaredMessageTypeMode
+{
+    /// <summary>
+    /// Nothing happens (silent failure).
+    /// </summary>
+    DoNothing = 0,
+    /// <summary>
+    /// An INFO log is generated for every message type that was encountered. THe log happens only once for each message type.
+    /// </summary>
+    RaiseOneTimeLog = 1,
+    /// <summary>
+    /// Raises an exception (every time message is produced).
+    /// </summary>
+    RaiseException = 2,
+}
+
+public enum PublishExecutionMode
 {
     /// <summary>
     /// Execute the publish on the first bus, then on the next (one after another).

--- a/src/SlimMessageBus.Host/MessageBusBase.cs
+++ b/src/SlimMessageBus.Host/MessageBusBase.cs
@@ -190,7 +190,7 @@ public abstract class MessageBusBase : IDisposable, IAsyncDisposable, IMasterMes
 
     private async Task OnBusLifecycle(MessageBusLifecycleEventType eventType)
     {
-        _lifecycleInterceptors ??= Settings.ServiceProvider?.GetServices<IMessageBusLifecycleInterceptor>();
+        _lifecycleInterceptors ??= Settings.ServiceProvider?.GetService<IEnumerable<IMessageBusLifecycleInterceptor>>();
         if (_lifecycleInterceptors != null)
         {
             foreach (var i in _lifecycleInterceptors)
@@ -256,8 +256,8 @@ public abstract class MessageBusBase : IDisposable, IAsyncDisposable, IMasterMes
         }
     }
 
-    protected virtual Task OnStart() => Task.CompletedTask;
-    protected virtual Task OnStop() => Task.CompletedTask;
+    protected internal virtual Task OnStart() => Task.CompletedTask;
+    protected internal virtual Task OnStop() => Task.CompletedTask;
 
     protected void AssertActive()
     {

--- a/src/Tests/SlimMessageBus.Host.Test.Common/MoqMatchers.cs
+++ b/src/Tests/SlimMessageBus.Host.Test.Common/MoqMatchers.cs
@@ -1,0 +1,11 @@
+﻿namespace SlimMessageBus.Host.Test.Common;
+
+public static class MoqMatchers
+{
+    public static bool LogMessageMatcher(object formattedLogValueObject, Func<string, bool> messageMatch)
+    {
+        var logValues = formattedLogValueObject as IReadOnlyList<KeyValuePair<string, object>>;
+        var originalFormat = logValues?.FirstOrDefault(logValue => logValue.Key == "{OriginalFormat}").Value.ToString();
+        return originalFormat != null && messageMatch(originalFormat);
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Test.Common/XunitLoggerFactory.cs
+++ b/src/Tests/SlimMessageBus.Host.Test.Common/XunitLoggerFactory.cs
@@ -3,7 +3,7 @@
 public class XunitLoggerFactory : ILoggerFactory
 {
     private readonly ITestOutputHelper _output;
-    
+
     public ITestOutputHelper Output => _output;
 
     public XunitLoggerFactory(ITestOutputHelper output) => _output = output;


### PR DESCRIPTION
* Hybrid bus now has an additional setting `HybridMessageBusSettings.UndeclaredMessageTypeMode` that allows to set what should happen when a message type is being published that was not declared.
* The default has changed from raising an exception to generation of log (one time)

* Closes #199 

```cs
public class HybridMessageBusSettings
{
    /// <summary>
    /// When a message type is being produced that has no matching child bus that can produce such a message, defines the mode of execution.
    /// </summary>
    /// <remarks>The default is <see cref="UndeclaredMessageTypeMode.RaiseOneTimeLog"/>.</remarks>
    public UndeclaredMessageTypeMode UndeclaredMessageTypeMode { get; set; } = UndeclaredMessageTypeMode.RaiseOneTimeLog;
}

public enum UndeclaredMessageTypeMode
{
    /// <summary>
    /// Nothing happens (silent failure).
    /// </summary>
    DoNothing = 0,
    /// <summary>
    /// An INFO log is generated for every message type that was encountered. THe log happens only once for each message type.
    /// </summary>
    RaiseOneTimeLog = 1,
    /// <summary>
    /// Raises an exception (every time message is produced).
    /// </summary>
    RaiseException = 2,
}
```