### PR TITLE
[Host.RabbitMQ] Document how to achieve concurrent message processing #205

### DIFF
--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqMessageBusSettingsExtensions.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqMessageBusSettingsExtensions.cs
@@ -7,7 +7,7 @@ public static class RabbitMqMessageBusSettingsExtensions
     /// </summary>
     /// <param name="settings"></param>
     /// <param name="action">Action to be executed, the first param is the RabbitMQ <see cref="IModel"/> from the underlying client, and second parameter represents the SMB exchange, queue and binding setup</param>
-    public static RabbitMqMessageBusSettings UseTopologyInitalizer(this RabbitMqMessageBusSettings settings, RabbitMqTopologyInitializer action)
+    public static RabbitMqMessageBusSettings UseTopologyInitializer(this RabbitMqMessageBusSettings settings, RabbitMqTopologyInitializer action)
     {
         if (action == null) throw new ArgumentNullException(nameof(action));
 

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/IntegrationTests/RabbitMqMessageBusIt.cs
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/IntegrationTests/RabbitMqMessageBusIt.cs
@@ -43,7 +43,7 @@ public class RabbitMqMessageBusIt : BaseIntegrationTest<RabbitMqMessageBusIt>
                 cfg.UseExchangeDefaults(durable: false);
                 cfg.UseDeadLetterExchangeDefaults(durable: false, autoDelete: false, exchangeType: ExchangeType.Direct, routingKey: string.Empty);
                 cfg.UseQueueDefaults(durable: false);
-                cfg.UseTopologyInitalizer((channel, applyDefaultTopology) =>
+                cfg.UseTopologyInitializer((channel, applyDefaultTopology) =>
                 {
                     // before test clean up
                     channel.QueueDelete("subscriber-0", ifUnused: true, ifEmpty: false);


### PR DESCRIPTION
- Update RabbitMQ docs to clarify #205
- Fix typo around `.UseTopologyInitializer()` - it was `.UseTopologyInitalizer()`