### PR TITLE
[Host] Optionally include IConsumerContext and/or CancellationToken in consumer method invocation

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -219,12 +219,13 @@ The `SomeConsumer` needs to be registered in the DI container. The SMB runtime w
 
 > When `.WithConsumer<TConsumer>()` is not declared, then a default consumer of type `IConsumer<TMessage>` will be assumed (since v2.0.0).
 
-Alternatively, if you do not want to implement the `IConsumer<SomeMessage>`, then you can provide the method name (2) or a delegate that calls the consumer method (3):
+Alternatively, if you do not want to implement the `IConsumer<SomeMessage>`, then you can provide the method name (2) or a delegate that calls the consumer method (3).
+`IConsumerContext` and/or `CancellationToken` can optionally be included as parameters to be populated on invocation when taking this approach:
 
 ```cs
 public class SomeConsumer
 {
-  public async Task MyHandleMethod(SomeMessage msg)
+  public async Task MyHandleMethod(SomeMessage msg, IConsumerContext consumerContext, CancellationToken cancellationToken)
   {
     // handle the msg
   }

--- a/src/SlimMessageBus.Host.Configuration/Builders/ConsumerBuilder.cs
+++ b/src/SlimMessageBus.Host.Configuration/Builders/ConsumerBuilder.cs
@@ -37,7 +37,7 @@ public class ConsumerBuilder<T> : AbstractConsumerBuilder
         where TConsumer : class, IConsumer<T>
     {
         ConsumerSettings.ConsumerType = typeof(TConsumer);
-        ConsumerSettings.ConsumerMethod = (consumer, message) => ((IConsumer<T>)consumer).OnHandle((T)message);
+        ConsumerSettings.ConsumerMethod = (consumer, message, _, _) => ((IConsumer<T>)consumer).OnHandle((T)message);
 
         ConsumerSettings.Invokers.Add(ConsumerSettings);
 
@@ -58,7 +58,7 @@ public class ConsumerBuilder<T> : AbstractConsumerBuilder
 
         var invoker = new MessageTypeConsumerInvokerSettings(ConsumerSettings, messageType: typeof(TMessage), consumerType: typeof(TConsumer))
         {
-            ConsumerMethod = (consumer, message) => ((IConsumer<TMessage>)consumer).OnHandle((TMessage)message)
+            ConsumerMethod = (consumer, message, _, _) => ((IConsumer<TMessage>)consumer).OnHandle((TMessage)message)
         };
         ConsumerSettings.Invokers.Add(invoker);
 
@@ -71,7 +71,7 @@ public class ConsumerBuilder<T> : AbstractConsumerBuilder
     /// </summary>
     /// <typeparam name="TConsumer"></typeparam>
     /// <returns></returns>
-    public ConsumerBuilder<T> WithConsumer(Type derivedConsumerType, Type derivedMessageType)
+    public ConsumerBuilder<T> WithConsumer(Type derivedConsumerType, Type derivedMessageType, string methodName = null)
     {
         AssertInvokerUnique(derivedConsumerType, derivedMessageType);
 
@@ -81,7 +81,7 @@ public class ConsumerBuilder<T> : AbstractConsumerBuilder
         }
 
         var invoker = new MessageTypeConsumerInvokerSettings(ConsumerSettings, messageType: derivedMessageType, consumerType: derivedConsumerType);
-        SetupConsumerOnHandleMethod(invoker);
+        SetupConsumerOnHandleMethod(invoker, methodName);
         ConsumerSettings.Invokers.Add(invoker);
 
         return this;
@@ -99,7 +99,7 @@ public class ConsumerBuilder<T> : AbstractConsumerBuilder
         if (consumerMethod == null) throw new ArgumentNullException(nameof(consumerMethod));
 
         ConsumerSettings.ConsumerType = typeof(TConsumer);
-        ConsumerSettings.ConsumerMethod = (consumer, message) => consumerMethod((TConsumer)consumer, (T)message);
+        ConsumerSettings.ConsumerMethod = (consumer, message, _, _) => consumerMethod((TConsumer)consumer, (T)message);
 
         ConsumerSettings.Invokers.Add(ConsumerSettings);
 

--- a/src/SlimMessageBus.Host.Configuration/Builders/HandlerBuilder.cs
+++ b/src/SlimMessageBus.Host.Configuration/Builders/HandlerBuilder.cs
@@ -130,7 +130,7 @@ public class HandlerBuilder<TRequest, TResponse> : AbstractHandlerBuilder<TReque
         where THandler : IRequestHandler<TRequest, TResponse>
     {
         ConsumerSettings.ConsumerType = typeof(THandler);
-        ConsumerSettings.ConsumerMethod = (consumer, message) => ((THandler)consumer).OnHandle((TRequest)message);
+        ConsumerSettings.ConsumerMethod = (consumer, message, _, _) => ((THandler)consumer).OnHandle((TRequest)message);
 
         ConsumerSettings.Invokers.Add(ConsumerSettings);
 
@@ -152,7 +152,7 @@ public class HandlerBuilder<TRequest, TResponse> : AbstractHandlerBuilder<TReque
 
         var invoker = new MessageTypeConsumerInvokerSettings(ConsumerSettings, messageType: typeof(TDerivedRequest), consumerType: typeof(THandler))
         {
-            ConsumerMethod = (consumer, message) => ((IRequestHandler<TDerivedRequest, TResponse>)consumer).OnHandle((TDerivedRequest)message)
+            ConsumerMethod = (consumer, message, _, _) => ((IRequestHandler<TDerivedRequest, TResponse>)consumer).OnHandle((TDerivedRequest)message)
         };
         ConsumerSettings.Invokers.Add(invoker);
 
@@ -178,7 +178,7 @@ public class HandlerBuilder<TRequest> : AbstractHandlerBuilder<TRequest, Handler
         where THandler : IRequestHandler<TRequest>
     {
         ConsumerSettings.ConsumerType = typeof(THandler);
-        ConsumerSettings.ConsumerMethod = (consumer, message) => ((THandler)consumer).OnHandle((TRequest)message);
+        ConsumerSettings.ConsumerMethod = (consumer, message, _, _) => ((THandler)consumer).OnHandle((TRequest)message);
 
         ConsumerSettings.Invokers.Add(ConsumerSettings);
 
@@ -200,7 +200,7 @@ public class HandlerBuilder<TRequest> : AbstractHandlerBuilder<TRequest, Handler
 
         var invoker = new MessageTypeConsumerInvokerSettings(ConsumerSettings, messageType: typeof(TDerivedRequest), consumerType: typeof(THandler))
         {
-            ConsumerMethod = (consumer, message) => ((IRequestHandler<TDerivedRequest>)consumer).OnHandle((TDerivedRequest)message)
+            ConsumerMethod = (consumer, message, _, _) => ((IRequestHandler<TDerivedRequest>)consumer).OnHandle((TDerivedRequest)message)
         };
         ConsumerSettings.Invokers.Add(invoker);
 

--- a/src/SlimMessageBus.Host.Configuration/Settings/ConsumerSettings.cs
+++ b/src/SlimMessageBus.Host.Configuration/Settings/ConsumerSettings.cs
@@ -28,7 +28,7 @@ public class ConsumerSettings : AbstractConsumerSettings, IMessageTypeConsumerIn
     /// <inheritdoc/>
     public Type ConsumerType { get; set; }
     /// <inheritdoc/>
-    public Func<object, object, Task> ConsumerMethod { get; set; }
+    public Func<object, object, IConsumerContext, CancellationToken, Task> ConsumerMethod { get; set; }
     /// <inheritdoc/>
     public MethodInfo ConsumerMethodInfo { get; set; }
     /// <summary>

--- a/src/SlimMessageBus.Host.Configuration/Settings/IMessageTypeConsumerInvokerSettings.cs
+++ b/src/SlimMessageBus.Host.Configuration/Settings/IMessageTypeConsumerInvokerSettings.cs
@@ -14,7 +14,7 @@ public interface IMessageTypeConsumerInvokerSettings
     /// <summary>
     /// The delegate to the consumer method responsible for accepting messages.
     /// </summary>
-    Func<object, object, Task> ConsumerMethod { get; set; }
+    Func<object, object, IConsumerContext, CancellationToken, Task> ConsumerMethod { get; set; }
     /// <summary>
     /// The consumer method.
     /// </summary>

--- a/src/SlimMessageBus.Host.Configuration/Settings/MessageTypeConsumerInvokerSettings.cs
+++ b/src/SlimMessageBus.Host.Configuration/Settings/MessageTypeConsumerInvokerSettings.cs
@@ -11,7 +11,7 @@ public class MessageTypeConsumerInvokerSettings : IMessageTypeConsumerInvokerSet
     /// <inheritdoc/>
     public Type ConsumerType { get; }
     /// <inheritdoc/>
-    public Func<object, object, Task> ConsumerMethod { get; set; }
+    public Func<object, object, IConsumerContext, CancellationToken, Task> ConsumerMethod { get; set; }
     /// <inheritdoc/>
     public MethodInfo ConsumerMethodInfo { get; set; }
 

--- a/src/SlimMessageBus.Host/Consumer/Context/ConsumerContext.cs
+++ b/src/SlimMessageBus.Host/Consumer/Context/ConsumerContext.cs
@@ -8,7 +8,7 @@ public class ConsumerContext(IDictionary<string, object> properties = null) : IC
 
     public IReadOnlyDictionary<string, object> Headers { get; set; }
 
-    public CancellationToken CancellationToken { get; set; }
+    public CancellationToken CancellationToken { get; set; } = default;
 
     public IMessageBus Bus { get; set; }
 

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/MessageHandler.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/MessageHandler.cs
@@ -202,7 +202,7 @@ public class MessageHandler : IMessageHandler
         }
 
         // the consumer just subscribes to the message
-        var task = consumerInvoker.ConsumerMethod(consumerContext.Consumer, message);
+        var task = consumerInvoker.ConsumerMethod(consumerContext.Consumer, message, consumerContext, consumerContext.CancellationToken);
         await task.ConfigureAwait(false);
 
         if (responseType != null && responseType != typeof(Void))

--- a/src/SlimMessageBus.Host/DependencyResolver/ConsumerMethodPostProcessor.cs
+++ b/src/SlimMessageBus.Host/DependencyResolver/ConsumerMethodPostProcessor.cs
@@ -8,7 +8,7 @@ public class ConsumerMethodPostProcessor : IMessageBusSettingsPostProcessor
             .SelectMany(x => x.Invokers).ToList();
         foreach (var consumerInvoker in consumerInvokers.Where(x => x.ConsumerMethod == null && x.ConsumerMethodInfo != null))
         {
-            consumerInvoker.ConsumerMethod = ReflectionUtils.GenerateMethodCallToFunc<Func<object, object, Task>>(consumerInvoker.ConsumerMethodInfo, consumerInvoker.ConsumerType, typeof(Task), consumerInvoker.MessageType);
+            consumerInvoker.ConsumerMethod = ReflectionUtils.GenerateMethodCallToFunc<Func<object, object, IConsumerContext, CancellationToken, Task>>(consumerInvoker.ConsumerMethodInfo, consumerInvoker.MessageType);
         }
     }
 }

--- a/src/SlimMessageBus.Host/Helpers/ReflectionUtils.cs
+++ b/src/SlimMessageBus.Host/Helpers/ReflectionUtils.cs
@@ -1,5 +1,6 @@
 ﻿namespace SlimMessageBus.Host;
 
+using System.Diagnostics;
 using System.Linq.Expressions;
 
 public static class ReflectionUtils
@@ -38,6 +39,101 @@ public static class ReflectionUtils
         var typedMethodResultExpr = Expression.Convert(methodResultExpr, returnType);
 
         return Expression.Lambda<T>(typedMethodResultExpr, new[] { objInstanceExpr }.Concat(objArguments)).Compile();
+    }
+
+    /// <summary>
+    /// Creates a delegate for the specified method wrapping both required and optional parameters. 
+    /// 
+    /// The first parameter in the delegate is the instance to invoke the method against and must be supplied as an object. 
+    /// Subsequent parameters that are supplied as objects and are typed (with index) in argumentTypes are required.
+    /// Any further parameters are typed and optional.
+    /// 
+    /// The target method can accept the parameters in any order. As such, types are explicit and cannot be duplicated.
+    /// </summary>
+    /// <typeparam name="TDelegate">Method facade</typeparam>
+    /// <param name="methodInfo">Target method to invoke</param>
+    /// <param name="argumentTypes">Required types (indexed 1.. in delegate)</param>
+    /// <returns></returns>
+    /// <example>
+    ///     GenerateMethodCallToFunc<Func<object, object, IConsumerContext, CancellationToken, Task>>(methodInfo, typeof(SampleMessage));
+    ///     
+    ///     Initial object is the instance to invoke the method on (type determined by methodInfo.DeclaringType)
+    ///     SampleMessage is required as a parameter defined by methodInfo
+    ///     IConsumerContext and CancellationToken are optional parameters as defined by methodInfo. If they exist, they will be populated otherwise ignored.
+    ///     
+    ///     methodInfo must:
+    ///         * be for an instance (static not supported in current implementation)
+    ///         * contain at least a parameter of type SampleMessage
+    ///         * optionally require parameters of type IConsumerContext and CancellationToken
+    ///         * require no other parameters
+    ///         * return a Task (as specified by the delegate)
+    /// </example>
+    /// <exception cref="ArgumentNullException"><see cref="methodInfo"/> is required</exception>
+    /// <exception cref="ArgumentException">Target invocation requires unsupplied parameter</exception>
+    /// <exception cref="ArgumentException">Required parameter(s) missing from target invocation</exception>
+    public static TDelegate GenerateMethodCallToFunc<TDelegate>(MethodInfo methodInfo, params Type[] argumentTypes)
+        where TDelegate : Delegate
+    {
+#if NETSTANDARD2_0
+        if (methodInfo == null) throw new ArgumentNullException(nameof(methodInfo));
+#else
+        ArgumentNullException.ThrowIfNull(methodInfo);
+#endif
+
+        var delegateSignature = typeof(TDelegate).GetMethod("Invoke")!;
+        Debug.Assert(delegateSignature.ReturnType == methodInfo.ReturnType);
+
+        var instanceParameter = Expression.Parameter(typeof(object), "instance");
+        var optionalTypes = delegateSignature.GetParameters()
+            .Skip(argumentTypes.Length + 1)
+            .Select(p => p.ParameterType);
+
+        var parameters = argumentTypes.Select(
+            (type, index) =>
+                new
+                {
+                    Expression = Expression.Parameter(typeof(object), $"arg{index}"),
+                    Required = true,
+                    Type = type
+                })
+            .Union(
+                optionalTypes.Select(
+                    (type, index) =>
+                        new
+                        {
+                            Expression = Expression.Parameter(type, $"optArg{index}"),
+                            Required = false,
+                            Type = type
+                        }))
+            .ToDictionary(x => x.Type, x => x);
+
+        var allParameters = parameters.Select(x => x.Value.Expression).ToList();
+
+        var argumentExpressions = methodInfo.GetParameters().Select(
+            p =>
+            {
+                if (parameters.TryGetValue(p.ParameterType, out var arg) && parameters.Remove(p.ParameterType))
+                {
+                    return Expression.Convert(arg.Expression, p.ParameterType);
+                }
+
+                throw new ArgumentException($"Target invocation requires unsupplied parameter {p.ParameterType.AssemblyQualifiedName}");
+            }).ToList();
+
+        var missing = parameters.Values.Where(x => x.Required).Select(x => $"'{x.Type.AssemblyQualifiedName}'").ToList();
+        if (missing.Count > 0)
+        {
+            throw new ArgumentException($"Required parameter(s) missing from target invocation ({string.Join(", ", missing)})");
+        }
+
+        var callExpression = Expression.Call(
+            Expression.Convert(instanceParameter, methodInfo.DeclaringType!),
+            methodInfo,
+            argumentExpressions);
+
+        var lambda = Expression.Lambda<TDelegate>(callExpression, new[] { instanceParameter }.Concat(allParameters));
+
+        return lambda.Compile();
     }
 
     public static T GenerateGenericMethodCallToFunc<T>(MethodInfo genericMethod, Type[] genericTypeArguments, Type instanceType, Type returnType, params Type[] argumentTypes)

--- a/src/Tests/SlimMessageBus.Host.Benchmark/ConsumerCallBenchmark.cs
+++ b/src/Tests/SlimMessageBus.Host.Benchmark/ConsumerCallBenchmark.cs
@@ -33,7 +33,12 @@ public class CallConsumerBenchmark
                 new Scenario("CompiledExpression",
                     message,
                     consumer,
-                    ReflectionUtils.GenerateMethodCallToFunc<Func<object, object, Task>>(onHandleMethodInfo, typeof(SomeMessageConsumer), typeof(Task), typeof(SomeMessage)))
+                    ReflectionUtils.GenerateMethodCallToFunc<Func<object, object, Task>>(onHandleMethodInfo, typeof(SomeMessageConsumer), typeof(Task), typeof(SomeMessage))),
+
+                new Scenario("CompiledExpressionWithOptional",
+                    message,
+                    consumer,
+                    ReflectionUtils.GenerateMethodCallToFunc<Func<object, object, Task>>(onHandleMethodInfo, [typeof(SomeMessage)]))
             };
         }
     }

--- a/src/Tests/SlimMessageBus.Host.Configuration.Test/ConsumerBuilderTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Configuration.Test/ConsumerBuilderTest.cs
@@ -72,6 +72,9 @@ public class ConsumerBuilderTest
         // arrange
         var topic = "topic";
 
+        var consumerContextMock = new Mock<IConsumerContext>();
+        consumerContextMock.SetupGet(x => x.CancellationToken).Returns(new CancellationToken());
+
         // act
         var subject = new ConsumerBuilder<BaseMessage>(messageBusSettings)
             .Topic(topic)
@@ -85,7 +88,7 @@ public class ConsumerBuilderTest
 
         subject.ConsumerSettings.ConsumerMode.Should().Be(ConsumerMode.Consumer);
         subject.ConsumerSettings.ConsumerType.Should().Be(typeof(BaseMessageConsumer));
-        Func<Task> call = () => subject.ConsumerSettings.ConsumerMethod(new BaseMessageConsumer(), new BaseMessage());
+        Func<Task> call = () => subject.ConsumerSettings.ConsumerMethod(new BaseMessageConsumer(), new BaseMessage(), consumerContextMock.Object, consumerContextMock.Object.CancellationToken);
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(BaseMessage));
 
         subject.ConsumerSettings.Invokers.Count.Should().Be(4);
@@ -94,28 +97,28 @@ public class ConsumerBuilderTest
         consumerInvokerSettings.MessageType.Should().Be(typeof(BaseMessage));
         consumerInvokerSettings.ConsumerType.Should().Be(typeof(BaseMessageConsumer));
         consumerInvokerSettings.ParentSettings.Should().BeSameAs(subject.ConsumerSettings);
-        call = () => consumerInvokerSettings.ConsumerMethod(new BaseMessageConsumer(), new BaseMessage());
+        call = () => consumerInvokerSettings.ConsumerMethod(new BaseMessageConsumer(), new BaseMessage(), consumerContextMock.Object, consumerContextMock.Object.CancellationToken);
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(BaseMessage));
 
         consumerInvokerSettings = subject.ConsumerSettings.Invokers.Single(x => x.MessageType == typeof(DerivedAMessage));
         consumerInvokerSettings.MessageType.Should().Be(typeof(DerivedAMessage));
         consumerInvokerSettings.ConsumerType.Should().Be(typeof(DerivedAMessageConsumer));
         consumerInvokerSettings.ParentSettings.Should().BeSameAs(subject.ConsumerSettings);
-        call = () => consumerInvokerSettings.ConsumerMethod(new DerivedAMessageConsumer(), new DerivedAMessage());
+        call = () => consumerInvokerSettings.ConsumerMethod(new DerivedAMessageConsumer(), new DerivedAMessage(), consumerContextMock.Object, consumerContextMock.Object.CancellationToken);
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(DerivedAMessage));
 
         consumerInvokerSettings = subject.ConsumerSettings.Invokers.Single(x => x.MessageType == typeof(DerivedBMessage));
         consumerInvokerSettings.MessageType.Should().Be(typeof(DerivedBMessage));
         consumerInvokerSettings.ConsumerType.Should().Be(typeof(DerivedBMessageConsumer));
         consumerInvokerSettings.ParentSettings.Should().BeSameAs(subject.ConsumerSettings);
-        call = () => consumerInvokerSettings.ConsumerMethod(new DerivedBMessageConsumer(), new DerivedBMessage());
+        call = () => consumerInvokerSettings.ConsumerMethod(new DerivedBMessageConsumer(), new DerivedBMessage(), consumerContextMock.Object, consumerContextMock.Object.CancellationToken);
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(DerivedBMessage));
 
         consumerInvokerSettings = subject.ConsumerSettings.Invokers.Single(x => x.MessageType == typeof(Derived2AMessage));
         consumerInvokerSettings.MessageType.Should().Be(typeof(Derived2AMessage));
         consumerInvokerSettings.ConsumerType.Should().Be(typeof(Derived2AMessageConsumer));
         consumerInvokerSettings.ParentSettings.Should().BeSameAs(subject.ConsumerSettings);
-        call = () => consumerInvokerSettings.ConsumerMethod(new Derived2AMessageConsumer(), new Derived2AMessage());
+        call = () => consumerInvokerSettings.ConsumerMethod(new Derived2AMessageConsumer(), new Derived2AMessage(), consumerContextMock.Object, consumerContextMock.Object.CancellationToken);
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(Derived2AMessage));
     }
 
@@ -125,6 +128,9 @@ public class ConsumerBuilderTest
         // arrange
         var topic = "topic";
 
+        var consumerContextMock = new Mock<IConsumerContext>();
+        consumerContextMock.SetupGet(x => x.CancellationToken).Returns(new CancellationToken());
+
         // act
         var subject = new ConsumerBuilder<BaseRequest>(messageBusSettings)
             .Topic(topic)
@@ -132,12 +138,11 @@ public class ConsumerBuilderTest
             .WithConsumer<DerivedRequestConsumer, DerivedRequest>();
 
         // assert
-
         subject.ConsumerSettings.ResponseType.Should().Be(typeof(BaseResponse));
 
         subject.ConsumerSettings.ConsumerMode.Should().Be(ConsumerMode.Consumer);
         subject.ConsumerSettings.ConsumerType.Should().Be(typeof(BaseRequestConsumer));
-        Func<Task> call = () => subject.ConsumerSettings.ConsumerMethod(new BaseRequestConsumer(), new BaseRequest());
+        Func<Task> call = () => subject.ConsumerSettings.ConsumerMethod(new BaseRequestConsumer(), new BaseRequest(), consumerContextMock.Object, consumerContextMock.Object.CancellationToken);
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(BaseRequest));
 
         subject.ConsumerSettings.Invokers.Count.Should().Be(2);
@@ -146,14 +151,14 @@ public class ConsumerBuilderTest
         consumerInvokerSettings.MessageType.Should().Be(typeof(BaseRequest));
         consumerInvokerSettings.ConsumerType.Should().Be(typeof(BaseRequestConsumer));
         consumerInvokerSettings.ParentSettings.Should().BeSameAs(subject.ConsumerSettings);
-        call = () => consumerInvokerSettings.ConsumerMethod(new BaseRequestConsumer(), new BaseRequest());
+        call = () => consumerInvokerSettings.ConsumerMethod(new BaseRequestConsumer(), new BaseRequest(), consumerContextMock.Object, consumerContextMock.Object.CancellationToken);
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(BaseRequest));
 
         consumerInvokerSettings = subject.ConsumerSettings.Invokers.Single(x => x.MessageType == typeof(DerivedRequest));
         consumerInvokerSettings.MessageType.Should().Be(typeof(DerivedRequest));
         consumerInvokerSettings.ConsumerType.Should().Be(typeof(DerivedRequestConsumer));
         consumerInvokerSettings.ParentSettings.Should().BeSameAs(subject.ConsumerSettings);
-        call = () => consumerInvokerSettings.ConsumerMethod(new DerivedRequestConsumer(), new DerivedRequest());
+        call = () => consumerInvokerSettings.ConsumerMethod(new DerivedRequestConsumer(), new DerivedRequest(), consumerContextMock.Object, consumerContextMock.Object.CancellationToken);
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(DerivedRequest));
     }
 

--- a/src/Tests/SlimMessageBus.Host.Configuration.Test/HandlerBuilderTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Configuration.Test/HandlerBuilderTest.cs
@@ -45,6 +45,9 @@ public class HandlerBuilderTest
         // arrange
         var path = "topic";
 
+        var consumerContextMock = new Mock<IConsumerContext>();
+        consumerContextMock.SetupGet(x => x.CancellationToken).Returns(new CancellationToken());
+
         // act
         var subject = new HandlerBuilder<SomeRequest, SomeResponse>(messageBusSettings)
             .Topic(path)
@@ -66,7 +69,7 @@ public class HandlerBuilderTest
         var consumerInvokerSettings = subject.ConsumerSettings.Invokers.Single(x => x.MessageType == typeof(SomeRequest));
         consumerInvokerSettings.MessageType.Should().Be(typeof(SomeRequest));
         consumerInvokerSettings.ConsumerType.Should().Be(typeof(SomeRequestMessageHandler));
-        Func<Task> call = () => consumerInvokerSettings.ConsumerMethod(new SomeRequestMessageHandler(), new SomeRequest());
+        Func<Task> call = () => consumerInvokerSettings.ConsumerMethod(new SomeRequestMessageHandler(), new SomeRequest(), consumerContextMock.Object, consumerContextMock.Object.CancellationToken);
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(SomeRequest));
     }
 
@@ -75,6 +78,9 @@ public class HandlerBuilderTest
     {
         // arrange
         var path = "topic";
+
+        var consumerContextMock = new Mock<IConsumerContext>();
+        consumerContextMock.SetupGet(x => x.CancellationToken).Returns(new CancellationToken());
 
         // act
         var subject = new HandlerBuilder<SomeRequestWithoutResponse>(messageBusSettings)
@@ -97,7 +103,7 @@ public class HandlerBuilderTest
         var consumerInvokerSettings = subject.ConsumerSettings.Invokers.Single(x => x.MessageType == typeof(SomeRequestWithoutResponse));
         consumerInvokerSettings.MessageType.Should().Be(typeof(SomeRequestWithoutResponse));
         consumerInvokerSettings.ConsumerType.Should().Be(typeof(SomeRequestWithoutResponseHandler));
-        Func<Task> call = () => consumerInvokerSettings.ConsumerMethod(new SomeRequestWithoutResponseHandler(), new SomeRequestWithoutResponse());
+        Func<Task> call = () => consumerInvokerSettings.ConsumerMethod(new SomeRequestWithoutResponseHandler(), new SomeRequestWithoutResponse(), consumerContextMock.Object, consumerContextMock.Object.CancellationToken);
         call.Should().ThrowAsync<NotImplementedException>().WithMessage(nameof(SomeRequestWithoutResponse));
     }
 }

--- a/src/Tests/SlimMessageBus.Host.Test/SampleMessages.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/SampleMessages.cs
@@ -51,3 +51,12 @@ public record Envelope<T>
 {
     public T Body { get; set; }
 }
+
+public interface ICustomConsumer<T>
+{
+    Task HandleAMessage(T message, CancellationToken cancellationToken);
+
+    Task HandleAMessageWithAContext(T message, IConsumerContext consumerContext, CancellationToken cancellationToken);
+
+    Task MethodThatHasParamatersThatCannotBeSatisfied(T message, DateTimeOffset dateTimeOffset, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
Added support for optionally including IConsumerContext and/or the CancellationToken in the consumer method invocation when supplying a type and method name. 

As the `CancellationToken` is tied to the life of the message lock, it should be readily available in the method to prematurely terminate processing when the lock is lost.

Supplying the `IConsumerContext` as an argument, as opposed to constructor or setting injection, allows for a single consumer instance where appropriate.

```cs
public class SomeConsumer
{
  public async Task MyHandleMethod(SomeMessage msg, IConsumerContext consumerContext, CancellationToken cancellationToken)
  {
    // handle the msg
  }
}
```

Please note that the order of the parameters is not important.

---
IConsumer and IRequestHandler have not been modified so as to avoid creating a breaking change. Implementation would be trivial should there be appetite to change the signatures.

Though not direct solutions to #220 and #223, the submission addresses both issues for non-IConsumer/IRequestHandler implementations.