### PR TITLE
[Host.HybridMessageSerialzier] Resolve HybridMessageSerializer dependencies from IServiceProvider

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -175,21 +175,27 @@ The Hybrid plugin allows to have multiple serialization formats on one message b
 To use it install the nuget package `SlimMessageBus.Host.Serialization.Hybrid` and then configure the bus:
 
 ```cs
-services.AddSlimMessageBus(mbb => 
-{
-   // serializer 1
-   var avroSerializer = new AvroMessageSerializer();
+    services
+       .AddSlimMessageBus(mbb =>
+        {
+            mbb
+                .AddHybridSerializer(
+                    builder => {
+                        builder
+                            .AsDefault()
+                            .AddJsonSerializer();
 
-   // serializer 2
-   var jsonSerializer = new JsonMessageSerializer();
+                        builder
+                            .For(typeof(Message1), typeof(Message2))
+                            .AddAvroSerializer();
 
-   // Note: Certain messages will be serialized by the Avro serializer, other using the Json serializer
-   mbb.AddHybridSerializer(new Dictionary<IMessageSerializer, Type[]>
-   {
-      [jsonSerializer] = new[] { typeof(SubtractCommand) }, // the first one will be the default serializer, no need to declare types here
-      [avroSerializer] = new[] { typeof(AddCommand), typeof(MultiplyRequest), typeof(MultiplyResponse) },
-   }, defaultMessageSerializer: jsonSerializer);
-});
+                        builder
+                            .For(typeof(Message3))
+                            .AddGoogleProtobufSerializer();
+                    })
+                ...
+        } 
 ```
 
+The routing to the proper serializer happens based on message type. When a type cannot be matched the default serializer will be used.
 The routing to the proper serializer happens based on message type. When a type cannot be matched the default serializer will be used.

--- a/src/SlimMessageBus.Host.Configuration/Builders/ISerializationBuilder.cs
+++ b/src/SlimMessageBus.Host.Configuration/Builders/ISerializationBuilder.cs
@@ -1,5 +1,6 @@
 ﻿namespace SlimMessageBus.Host;
 
-public interface ISerializationBuilder : IHasPostConfigurationActions
+public interface ISerializationBuilder
 {
+    void RegisterSerializer<TMessageSerializer>(Action<IServiceCollection> services) where TMessageSerializer : class, IMessageSerializer;
 }

--- a/src/SlimMessageBus.Host.Serialization.Avro/SerializationBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.Avro/SerializationBuilderExtensions.cs
@@ -18,10 +18,9 @@ public static class SerializationBuilderExtensions
     public static TBuilder AddAvroSerializer<TBuilder>(this TBuilder builder, IMessageCreationStrategy messageCreationStrategy, ISchemaLookupStrategy schemaLookupStrategy)
         where TBuilder : ISerializationBuilder
     {
-        builder.PostConfigurationActions.Add(services =>
+        builder.RegisterSerializer<AvroMessageSerializer>(services =>
         {
             services.TryAddSingleton(svp => new AvroMessageSerializer(svp.GetRequiredService<ILoggerFactory>(), messageCreationStrategy, schemaLookupStrategy));
-            services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<AvroMessageSerializer>());
         });
         return builder;
     }
@@ -35,10 +34,9 @@ public static class SerializationBuilderExtensions
     public static TBuilder AddAvroSerializer<TBuilder>(this TBuilder builder)
         where TBuilder : ISerializationBuilder
     {
-        builder.PostConfigurationActions.Add(services =>
+        builder.RegisterSerializer<AvroMessageSerializer>(services =>
         {
             services.TryAddSingleton(svp => new AvroMessageSerializer(svp.GetRequiredService<ILoggerFactory>()));
-            services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<AvroMessageSerializer>());
         });
         return builder;
     }

--- a/src/SlimMessageBus.Host.Serialization.GoogleProtobuf/SerializationBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.GoogleProtobuf/SerializationBuilderExtensions.cs
@@ -17,10 +17,9 @@ public static class SerializationBuilderExtensions
     public static TBuilder AddGoogleProtobufSerializer<TBuilder>(this TBuilder builder, IMessageParserFactory messageParserFactory = null)
         where TBuilder : ISerializationBuilder
     {
-        builder.PostConfigurationActions.Add(services =>
+        builder.RegisterSerializer<GoogleProtobufMessageSerializer>(services =>
         {
             services.TryAddSingleton(svp => new GoogleProtobufMessageSerializer(svp.GetRequiredService<ILoggerFactory>(), messageParserFactory));
-            services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<GoogleProtobufMessageSerializer>());
         });
         return builder;
     }

--- a/src/SlimMessageBus.Host.Serialization.Hybrid/SerializationBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.Hybrid/SerializationBuilderExtensions.cs
@@ -18,11 +18,120 @@ public static class SerializationBuilderExtensions
     public static TBuilder AddHybridSerializer<TBuilder>(this TBuilder builder, IDictionary<IMessageSerializer, Type[]> registration, IMessageSerializer defaultMessageSerializer)
         where TBuilder : ISerializationBuilder
     {
-        builder.PostConfigurationActions.Add(services =>
+        builder.RegisterSerializer<HybridMessageSerializer>(services =>
         {
             services.TryAddSingleton(svp => new HybridMessageSerializer(svp.GetRequiredService<ILogger<HybridMessageSerializer>>(), registration, defaultMessageSerializer));
-            services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<HybridMessageSerializer>());
         });
         return builder;
+    }
+
+    /// <summary>
+    /// Registers the <see cref="IMessageSerializer"/> with implementation as <see cref="HybridMessageSerializer"/> using serializers as registered in the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="mbb"><see cref="MessageBusBuilder"/></param>
+    /// <param name="registration">Action to register serializers for dependency injection resolution.</param>
+    /// <returns><see cref="MessageBusBuilder"/></returns>
+    public static MessageBusBuilder AddHybridSerializer(this MessageBusBuilder mbb, Action<HybridSerializerOptionsBuilder> registration)
+    {
+        var builder = new HybridSerializerOptionsBuilder();
+        registration(builder);
+
+        foreach (var action in builder.ServiceRegistrations)
+        {
+            mbb.PostConfigurationActions.Add(action);
+        }
+
+        mbb.PostConfigurationActions.Add(services =>
+        {
+            services.TryAddSingleton(svp =>
+            {
+                if (services.Count(x => x.ServiceType == typeof(IMessageSerializer)) > 1)
+                {
+                    throw new NotSupportedException($"Registering instances of {nameof(IMessageSerializer)} outside of {nameof(AddHybridSerializer)} is not supported.");
+                }
+
+                var defaultMessageSerializer = builder.DefaultSerializer != null ? (IMessageSerializer)svp.GetRequiredService(builder.DefaultSerializer) : null;
+                var typeRegistrations = builder.TypeRegistrations.ToDictionary(x => (IMessageSerializer)svp.GetRequiredService(x.Key), x => x.Value);
+                return new HybridMessageSerializer(svp.GetRequiredService<ILogger<HybridMessageSerializer>>(), typeRegistrations, defaultMessageSerializer);
+            });
+
+            services.AddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<HybridMessageSerializer>());
+        });
+        return mbb;
+    }
+
+    public sealed class HybridSerializerOptionsBuilder
+    {
+        private readonly List<SerializerConfiguration> _configurations = [];
+
+        public Type DefaultSerializer
+        {
+            get
+            {
+                return _configurations
+                    .OfType<DefaultSerializerConfiguration>()
+                    .LastOrDefault(x => x.IsValid)
+                    .Type;
+            }
+        }
+
+        public IReadOnlyList<Action<IServiceCollection>> ServiceRegistrations
+        {
+            get
+            {
+                return _configurations
+                    .Where(x => x.IsValid)
+                    .Select(x => x.Action)
+                    .ToList();
+            }
+        }
+
+        public IReadOnlyDictionary<Type, Type[]> TypeRegistrations
+        {
+            get
+            {
+                return _configurations
+                    .OfType<ForSerializerConfiguration>()
+                    .Where(x => x.IsValid)
+                    .ToDictionary(x => x.Type, x => x.Types);
+            }
+        }
+
+        public ISerializationBuilder AsDefault()
+        {
+            var configuration = new DefaultSerializerConfiguration();
+            this._configurations.Add(configuration);
+            return configuration;
+        }
+
+        public ISerializationBuilder For(params Type[] types)
+        {
+            var configuration = new ForSerializerConfiguration(types);
+            this._configurations.Add(configuration);
+            return configuration;
+        }
+
+        public abstract class SerializerConfiguration : ISerializationBuilder
+        {
+            public Action<IServiceCollection> Action { get; private set; }
+            public bool IsValid => Type != null;
+            public Type Type { get; private set; } = null;
+
+            public void RegisterSerializer<TMessageSerializer>(Action<IServiceCollection> services)
+                where TMessageSerializer : class, IMessageSerializer
+            {
+                Type = typeof(TMessageSerializer);
+                Action = services;
+            }
+        }
+
+        public class ForSerializerConfiguration(Type[] types) : SerializerConfiguration, ISerializationBuilder
+        {
+            public Type[] Types { get; } = types;
+        }
+
+        public class DefaultSerializerConfiguration : SerializerConfiguration, ISerializationBuilder
+        {
+        }
     }
 }

--- a/src/SlimMessageBus.Host.Serialization.Hybrid/SlimMessageBus.Host.Serialization.Hybrid.csproj
+++ b/src/SlimMessageBus.Host.Serialization.Hybrid/SlimMessageBus.Host.Serialization.Hybrid.csproj
@@ -1,19 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../Host.Plugin.Properties.xml" />
+	<Import Project="../Host.Plugin.Properties.xml" />
 
-  <PropertyGroup>
-    <Description>Extension to SlimMessageBus that delegates serialization to the respective serialization plugin based on message type.</Description>
-    <PackageTags>SlimMessageBus Serialization messaging</PackageTags>
-  </PropertyGroup>
+	<PropertyGroup>
+		<Description>Extension to SlimMessageBus that delegates serialization to the respective serialization plugin based on message type.</Description>
+		<PackageTags>SlimMessageBus Serialization messaging</PackageTags>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\SlimMessageBus.Host.Configuration\SlimMessageBus.Host.Configuration.csproj" />
-    <ProjectReference Include="..\SlimMessageBus.Host.Serialization\SlimMessageBus.Host.Serialization.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\SlimMessageBus.Host.Configuration\SlimMessageBus.Host.Configuration.csproj" />
+		<ProjectReference Include="..\SlimMessageBus.Host.Serialization\SlimMessageBus.Host.Serialization.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<InternalsVisibleTo Include="SlimMessageBus.Host.Serialization.Hybrid.Test" />
+	</ItemGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Serialization.Json/SerializationBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.Json/SerializationBuilderExtensions.cs
@@ -22,10 +22,9 @@ public static class SerializationBuilderExtensions
     public static TBuilder AddJsonSerializer<TBuilder>(this TBuilder builder, Encoding encoding = null, JsonSerializerSettings jsonSerializerSettings = null)
         where TBuilder : ISerializationBuilder
     {
-        builder.PostConfigurationActions.Add(services =>
+        builder.RegisterSerializer<JsonMessageSerializer>(services =>
         {
             services.TryAddSingleton(svp => new JsonMessageSerializer(jsonSerializerSettings ?? svp.GetService<JsonSerializerSettings>(), encoding, svp.GetRequiredService<ILogger<JsonMessageSerializer>>()));
-            services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<JsonMessageSerializer>());
         });
         return builder;
     }

--- a/src/SlimMessageBus.Host.Serialization.SystemTextJson/SerializationBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.SystemTextJson/SerializationBuilderExtensions.cs
@@ -17,10 +17,8 @@ public static class SerializationBuilderExtensions
     public static TBuilder AddJsonSerializer<TBuilder>(this TBuilder builder, JsonSerializerOptions options = null)
         where TBuilder : ISerializationBuilder
     {
-        builder.PostConfigurationActions.Add(services =>
-        {
+        builder.RegisterSerializer<JsonMessageSerializer>(services => {
             services.TryAddSingleton(svp => new JsonMessageSerializer(options ?? svp.GetService<JsonSerializerOptions>()));
-            services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<JsonMessageSerializer>());
         });
         return builder;
     }

--- a/src/SlimMessageBus.sln
+++ b/src/SlimMessageBus.sln
@@ -236,6 +236,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlimMessageBus.Host.Sql.Com
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlimMessageBus.Host.Serialization.Avro.Test", "Tests\SlimMessageBus.Host.Serialization.Avro.Test\SlimMessageBus.Host.Serialization.Avro.Test.csproj", "{8507237C-68C3-46AD-B7DA-800791C6FDDB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlimMessageBus.Host.Serialization.Hybrid.Test", "Tests\SlimMessageBus.Host.Serialization.Hybrid.Test\SlimMessageBus.Host.Serialization.Hybrid.Test.csproj", "{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -740,6 +742,14 @@ Global
 		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Release|x86.ActiveCfg = Release|Any CPU
 		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Release|x86.Build.0 = Release|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Debug|x86.Build.0 = Debug|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Release|x86.ActiveCfg = Release|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -813,6 +823,7 @@ Global
 		{F5373E1D-A2B4-46CC-9B07-94F6655C8E29} = {9F005B5C-A856-4351-8C0C-47A8B785C637}
 		{5EED0E89-2475-40E0-81EF-0F05C9326612} = {9291D340-B4FA-44A3-8060-C14743FB1712}
 		{F19B7A21-7749-465A-8810-4C274A9E8956} = {9291D340-B4FA-44A3-8060-C14743FB1712}
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46} = {9F005B5C-A856-4351-8C0C-47A8B785C637}
 		{8507237C-68C3-46AD-B7DA-800791C6FDDB} = {9F005B5C-A856-4351-8C0C-47A8B785C637}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/SerializationBuilderExtensionsTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/SerializationBuilderExtensionsTest.cs
@@ -3,7 +3,7 @@
 public class SerializationBuilderExtensionsTest
 {
     [Fact]
-    public void When_AddJsonSerializer_Given_Builder_Then_ServicesRegistered()
+    public void When_AddAvroSerializer_Given_Builder_Then_ServicesRegistered()
     {
         // arrange
         var services = new ServiceCollection();

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/Helpers/SampleMessages.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/Helpers/SampleMessages.cs
@@ -1,0 +1,5 @@
+﻿namespace SlimMessageBus.Host.Serialization.Hybrid.Test.Helpers;
+
+public record SampleOne;
+public record SampleTwo;
+public record SampleThree;

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/HybridMessageSerializerTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/HybridMessageSerializerTests.cs
@@ -1,0 +1,103 @@
+﻿namespace SlimMessageBus.Host.Serialization.Hybrid.Test
+{
+
+    public class HybridMessageSerializerTests
+    {
+        [Fact]
+        public void When_ConstructorReceivesARepeatedDefinition_Then_ThrowException()
+        {
+            // arrange
+            var mockDefaultSerializer = new Mock<IMessageSerializer>();
+            var mockSerializer1 = new Mock<IMessageSerializer>();
+            var mockSerializer2 = new Mock<IMessageSerializer>();
+            var mockLogger = new Mock<ILogger<HybridMessageSerializer>>();
+
+            var serializers = new Dictionary<IMessageSerializer, Type[]>
+            {
+                { mockSerializer1.Object, new[] { typeof(SampleOne), typeof(SampleTwo) } },
+                { mockSerializer2.Object, new[] { typeof(SampleOne) } },
+            };
+
+            // act
+            var act = () => new HybridMessageSerializer(mockLogger.Object, serializers, mockDefaultSerializer.Object);
+
+            // assert
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void When_NoDefaultSerializerIsSupplied_Then_UseFirstSpecialist()
+        {
+            // arrange
+            var mockDefaultSerializer = new Mock<IMessageSerializer>();
+            var mockSerializer1 = new Mock<IMessageSerializer>();
+            var mockLogger = new Mock<ILogger<HybridMessageSerializer>>();
+
+            var serializers = new Dictionary<IMessageSerializer, Type[]>
+            {
+                { mockDefaultSerializer.Object, new[] { typeof(SampleOne) } },
+                { mockSerializer1.Object, new[] { typeof(SampleTwo) } },
+            };
+
+            // act
+            var target = new HybridMessageSerializer(mockLogger.Object, serializers, default);
+            var actual = target.DefaultSerializer;
+
+            // assert
+            actual.Should().BeEquivalentTo(mockDefaultSerializer.Object);
+        }
+
+        [Fact]
+        public void When_ASpecialisedMessageIsSerialized_Then_UseSpecializedSerializer()
+        {
+            // arrange
+            var mockDefaultSerializer = new Mock<IMessageSerializer>();
+
+            var mockSerializer1 = new Mock<IMessageSerializer>();
+            mockSerializer1.Setup(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>())).Verifiable(Times.Once());
+
+            var mockSerializer2 = new Mock<IMessageSerializer>();
+
+            var mockLogger = new Mock<ILogger<HybridMessageSerializer>>();
+            var serializers = new Dictionary<IMessageSerializer, Type[]>
+            {
+                { mockSerializer1.Object, new[] { typeof(SampleOne) } },
+                { mockSerializer2.Object, new[] { typeof(SampleTwo) } },
+            };
+
+            // act
+            var target = new HybridMessageSerializer(mockLogger.Object, serializers, mockDefaultSerializer.Object);
+            var _ = target.Serialize(typeof(SampleOne), new SampleOne());
+
+            // assert
+            mockSerializer1.Verify(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>()));
+            mockSerializer2.VerifyNoOtherCalls();
+            mockDefaultSerializer.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void When_AGenericMessageIsSerialized_Then_UseDefaultSerializer()
+        {
+            // arrange
+            var mockDefaultSerializer = new Mock<IMessageSerializer>();
+            mockDefaultSerializer.Setup(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>())).Verifiable(Times.Once());
+
+            var mockSerializer1 = new Mock<IMessageSerializer>();
+
+            var mockLogger = new Mock<ILogger<HybridMessageSerializer>>();
+            var serializers = new Dictionary<IMessageSerializer, Type[]>
+            {
+                { mockSerializer1.Object, new[] { typeof(SampleTwo) } }
+            };
+
+            // act
+            var target = new HybridMessageSerializer(mockLogger.Object, serializers, mockDefaultSerializer.Object);
+            var _ = target.Serialize(typeof(SampleOne), new SampleOne());
+
+            // assert
+            mockDefaultSerializer.Verify(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>()));
+            mockSerializer1.VerifyNoOtherCalls();
+        }
+    }
+}
+

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SerializationBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SerializationBuilderExtensionsTests.cs
@@ -1,0 +1,86 @@
+namespace SlimMessageBus.Host.Serialization.Hybrid.Test;
+
+using Microsoft.Extensions.DependencyInjection;
+
+public class SerializationBuilderExtensionsTests
+{
+    private readonly IServiceCollection _services;
+
+    public SerializationBuilderExtensionsTests()
+    {
+        // arrange
+        var mockLogger = new Mock<ILogger<HybridMessageSerializer>>();
+
+        _services = new ServiceCollection();
+        _services.AddSingleton(mockLogger.Object);
+
+        // act
+        _services.AddSlimMessageBus(cfg =>
+        {
+            cfg.AddHybridSerializer(builder =>
+            {
+                builder
+                    .AsDefault()
+                    .RegisterSerializer<SerializerOne>(services => services.AddSingleton<SerializerOne>());
+
+                builder
+                    .For(typeof(SampleTwo))
+                    .RegisterSerializer<SerializerTwo>(services => services.AddSingleton<SerializerTwo>());
+
+                builder
+                    .For(typeof(SampleThree))
+                    .RegisterSerializer<SerializerThree>(services => services.AddSingleton<SerializerThree>());
+            });
+        });
+    }
+
+    [Fact]
+    public void When_IMessageSerializerRegistrationsAlreadyExist_Then_RemovePreviousRegistrations()
+    {
+        // assert
+        _services.Count(x => x.ServiceType == typeof(IMessageSerializer)).Should().Be(1);
+    }
+
+    [Fact]
+    public void When_HybridMessageSerializerIsAdded_Then_RegisterAsIMessageSerializer()
+    {
+        // act
+        var serviceProvider = _services.BuildServiceProvider();
+        var target = serviceProvider.GetServices<IMessageSerializer>().ToList();
+
+        // assert
+        target.Count.Should().Be(1);
+        target.Single().GetType().Should().Be(typeof(HybridMessageSerializer));
+    }
+
+    [Fact]
+    public void When_HybridMessageSerializerIsAdded_Then_SerializersAndTypesShouldConfigured()
+    {
+        // act
+        var serviceProvider = _services.BuildServiceProvider();
+        var target = serviceProvider.GetService<HybridMessageSerializer>();
+
+        // assert
+        target.DefaultSerializer.GetType().Should().Be(typeof(SerializerOne));
+        target.SerializerByType.Count.Should().Be(2);
+        target.SerializerByType.Should().ContainKey(typeof(SampleTwo)).WhoseValue.Should().BeOfType<SerializerTwo>();
+        target.SerializerByType.Should().ContainKey(typeof(SampleThree)).WhoseValue.Should().BeOfType<SerializerThree>();
+    }
+
+    public abstract class AbstractSerializer : IMessageSerializer
+    {
+        public object Deserialize(Type t, byte[] payload)
+        {
+            throw new NotImplementedException();
+        }
+
+        public byte[] Serialize(Type t, object message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class SerializerOne : AbstractSerializer { }
+    public class SerializerTwo : AbstractSerializer { }
+    public class SerializerThree : AbstractSerializer { }
+}

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SlimMessageBus.Host.Serialization.Hybrid.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SlimMessageBus.Host.Serialization.Hybrid.Test.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Host.Test.Properties.xml" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.Hybrid\SlimMessageBus.Host.Serialization.Hybrid.csproj" />
+    <ProjectReference Include="..\..\SlimMessageBus.Host\SlimMessageBus.Host.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/Usings.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/Usings.cs
@@ -1,0 +1,9 @@
+global using FluentAssertions;
+
+global using Microsoft.Extensions.Logging;
+
+global using Moq;
+
+global using SlimMessageBus.Host.Serialization.Hybrid.Test.Helpers;
+
+global using Xunit;

--- a/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/JsonMessageSerializerTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/JsonMessageSerializerTests.cs
@@ -5,16 +5,15 @@ using FluentAssertions;
 public class JsonMessageSerializerTests
 {
     public static IEnumerable<object[]> Data =>
-        new List<object[]>
-        {
-            new object[] { null, null },
-            new object[] { 10, 10 },
-            new object[] { false, false },
-            new object[] { true, true },
-            new object[] { "string", "string" },
-            new object[] { DateTime.Now.Date, DateTime.Now.Date },
-            new object[] { Guid.Empty, "00000000-0000-0000-0000-000000000000" },
-        };
+        [
+            [null, null],
+            [10, 10],
+            [false, false],
+            [true, true],
+            ["string", "string"],
+            [DateTime.Now.Date, DateTime.Now.Date],
+            [Guid.Empty, "00000000-0000-0000-0000-000000000000"],
+        ];
 
     [Theory]
     [MemberData(nameof(Data))]


### PR DESCRIPTION
#238 PR to allow for serializers to be added and then resolved by the hybrid message serializer. 

By resolving the specialized serializers from the DI container, registration of those serializers can be performed via their included builders. This will then allow for the expected dependency resolution path to be followed for each of the specialized serializers ie. JsonMessageSerializer can use a supplied JsonSerializerOptions instance or resolve one from the DI container directly

***Caveat:***
The HybridMessageSerializer must be registered last so that it is able to remove previous IMessageSerializer registrations in order to make itself the designated serializer.

```c#
    services
        .AddSlimMessageBus(mbb =>
        {
            mbb
                // add required serializers to the DI container first
                .AddAvroSerializer()
                .AddGoogleProtobufSerializer()
                .AddJsonSerializer()
                
                // Add hybrid serializer last so that it can update DI container and set itself as the default
                .AddHybridSerializer<JsonMessageSerializer>(
                    o => {

                        // Message1, Message2 => AvroSerializer
                        // Message3 => GoogleProtobufMessageSerializer
                        // all other messages by JsonMessageSerializer

                        o.Add<AvroSerializer>(typeof(Message1), typeof(Message2));
                        o.Add<GoogleProtobufMessageSerializer>(typeof(Message3));
                    })
                ...
        } 

```

