### PR TITLE
[Host.HybridMessageSerialzier] #238 Resolve HybridMessageSerializer dependencies from IServiceProvider [Alternative implementation]

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -175,21 +175,26 @@ The Hybrid plugin allows to have multiple serialization formats on one message b
 To use it install the nuget package `SlimMessageBus.Host.Serialization.Hybrid` and then configure the bus:
 
 ```cs
-services.AddSlimMessageBus(mbb => 
-{
-   // serializer 1
-   var avroSerializer = new AvroMessageSerializer();
+    services
+       .AddSlimMessageBus(mbb =>
+        {
+            mbb
+                .AddHybridSerializer(
+                    builder => {
+                        builder
+                            .AddJsonSerializer()
+                            .AsDefault();
 
-   // serializer 2
-   var jsonSerializer = new JsonMessageSerializer();
+                        builder
+                            .AddAvroSerializer()
+                            .For(typeof(Message1), typeof(Message2));
 
-   // Note: Certain messages will be serialized by the Avro serializer, other using the Json serializer
-   mbb.AddHybridSerializer(new Dictionary<IMessageSerializer, Type[]>
-   {
-      [jsonSerializer] = new[] { typeof(SubtractCommand) }, // the first one will be the default serializer, no need to declare types here
-      [avroSerializer] = new[] { typeof(AddCommand), typeof(MultiplyRequest), typeof(MultiplyResponse) },
-   }, defaultMessageSerializer: jsonSerializer);
-});
+                        builder
+                            .AddGoogleProtobufSerializer()
+                            .For(typeof(Message3));
+                    })
+                ...
+        } 
 ```
 
 The routing to the proper serializer happens based on message type. When a type cannot be matched the default serializer will be used.

--- a/src/SlimMessageBus.Host.Configuration/Builders/IHybridSerializationBuilder.cs
+++ b/src/SlimMessageBus.Host.Configuration/Builders/IHybridSerializationBuilder.cs
@@ -1,0 +1,15 @@
+﻿namespace SlimMessageBus.Host.Builders
+{
+    using System;
+
+    public interface IHybridSerializationBuilder
+    {
+        IHybridSerializerBuilderOptions RegisterSerializer<TMessageSerializer>(Action<IServiceCollection> services = null) where TMessageSerializer : class, IMessageSerializer;
+    }
+
+    public interface IHybridSerializerBuilderOptions
+    {
+        IHybridSerializationBuilder For(params Type[] types);
+        IHybridSerializationBuilder AsDefault();
+    }
+}

--- a/src/SlimMessageBus.Host.Serialization.Avro/AvroMessageSerializer.cs
+++ b/src/SlimMessageBus.Host.Serialization.Avro/AvroMessageSerializer.cs
@@ -84,7 +84,7 @@ public class AvroMessageSerializer : IMessageSerializer
         var writerSchema = WriteSchemaLookup(t);
         AssertSchemaNotNull(t, writerSchema, true);
 
-        _logger.LogDebug("Type {0} writer schema: {1}, reader schema: {2}", t, writerSchema, readerSchema);
+        _logger.LogDebug("Type {MessageType} writer schema: {WriterSchema}, reader schema: {ReaderSchema}", t, writerSchema, readerSchema);
 
         var reader = new SpecificDefaultReader(writerSchema, readerSchema);
         reader.Read(message, dec);
@@ -108,7 +108,7 @@ public class AvroMessageSerializer : IMessageSerializer
         var writerSchema = WriteSchemaLookup(t);
         AssertSchemaNotNull(t, writerSchema, true);
 
-        _logger.LogDebug("Type {0} writer schema: {1}", t, writerSchema);
+        _logger.LogDebug("Type {MessageType} writer schema: {WriterSchema}", t, writerSchema);
 
         var writer = new SpecificDefaultWriter(writerSchema); // Schema comes from pre-compiled, code-gen phase
         writer.Write(message, enc);

--- a/src/SlimMessageBus.Host.Serialization.Avro/MessageBusBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.Avro/MessageBusBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 using SlimMessageBus.Host;
+using SlimMessageBus.Host.Builders;
 
 public static class MessageBusBuilderExtensions
 {
@@ -39,5 +40,31 @@ public static class MessageBusBuilderExtensions
             services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<AvroMessageSerializer>());
         });
         return mbb;
+    }
+
+    /// <summary>
+    /// Registers the <see cref="IMessageSerializer"/> with implementation as <see cref="AvroMessageSerializer"/>.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static IHybridSerializerBuilderOptions AddAvroSerializer(this IHybridSerializationBuilder builder, IMessageCreationStrategy messageCreationStrategy, ISchemaLookupStrategy schemaLookupStrategy)
+    {
+        return builder.RegisterSerializer<AvroMessageSerializer>(services =>
+        {
+            services.TryAddSingleton(svp => new AvroMessageSerializer(svp.GetRequiredService<ILoggerFactory>(), messageCreationStrategy, schemaLookupStrategy));
+        });
+    }
+
+    /// <summary>
+    /// Registers the <see cref="IMessageSerializer"/> with implementation as <see cref="AvroMessageSerializer"/>.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static IHybridSerializerBuilderOptions AddAvroSerializer(this IHybridSerializationBuilder builder)
+    {
+        return builder.RegisterSerializer<AvroMessageSerializer>(services =>
+        {
+            services.TryAddSingleton(svp => new AvroMessageSerializer(svp.GetRequiredService<ILoggerFactory>()));
+        });
     }
 }

--- a/src/SlimMessageBus.Host.Serialization.GoogleProtobuf/MessageBusBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.GoogleProtobuf/MessageBusBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 using SlimMessageBus.Host;
+using SlimMessageBus.Host.Builders;
 
 public static class MessageBusBuilderExtensions
 {
@@ -22,5 +23,19 @@ public static class MessageBusBuilderExtensions
             services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<GoogleProtobufMessageSerializer>());
         });
         return mbb;
+    }
+
+    /// <summary>
+    /// Registers the <see cref="IMessageSerializer"/> with implementation as <see cref="GoogleProtobufMessageSerializer"/>.
+    /// </summary>
+    /// <param name="mbb"></param>
+    /// <param name="messageParserFactory"></param>
+    /// <returns></returns>
+    public static IHybridSerializerBuilderOptions AddGoogleProtobufSerializer(this IHybridSerializationBuilder builder, IMessageParserFactory messageParserFactory = null)
+    {
+        return builder.RegisterSerializer<GoogleProtobufMessageSerializer>(services =>
+        {
+            services.TryAddSingleton(svp => new GoogleProtobufMessageSerializer(svp.GetRequiredService<ILoggerFactory>(), messageParserFactory));
+        });
     }
 }

--- a/src/SlimMessageBus.Host.Serialization.Hybrid/MessageBusBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.Hybrid/MessageBusBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 using SlimMessageBus.Host;
+using SlimMessageBus.Host.Builders;
 
 public static class MessageBusBuilderExtensions
 {
@@ -23,5 +24,108 @@ public static class MessageBusBuilderExtensions
             services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<HybridMessageSerializer>());
         });
         return mbb;
+    }
+
+    /// <summary>
+    /// Registers the <see cref="IMessageSerializer"/> with implementation as <see cref="HybridMessageSerializer"/> using serializers as registered in the <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="mbb"><see cref="MessageBusBuilder"/></param>
+    /// <param name="registration">Action to register serializers for dependency injection resolution.</param>
+    /// <returns><see cref="MessageBusBuilder"/></returns>
+    public static MessageBusBuilder AddHybridSerializer(this MessageBusBuilder mbb, Action<IHybridSerializationBuilder> registration)
+    {
+        var builder = new HybridSerializerOptionsBuilder();
+        registration(builder);
+
+        var registrations = builder.Registrations.Where(x => x.Key == builder.DefaultSerializer || x.Value.Types.Any()).ToList();
+
+        foreach (var messageSerializer in registrations)
+        {
+            mbb.PostConfigurationActions.Add(messageSerializer.Value.Registration);
+        }        
+
+        mbb.PostConfigurationActions.Add(services =>
+        {
+            services.TryAddSingleton(svp =>
+            {
+                if (services.Count(x => x.ServiceType == typeof(IMessageSerializer)) > 1)
+                {
+                    throw new NotSupportedException($"Registering instances of {nameof(IMessageSerializer)} with {nameof(IServiceCollection)} outside of {nameof(AddHybridSerializer)} is not supported.");
+                }
+
+                var registrationTypes = registrations.ToDictionary(x => (IMessageSerializer)svp.GetRequiredService(x.Key), x => x.Value.Types);
+                var defaultMessageSerializer = builder.DefaultSerializer != null ? (IMessageSerializer)svp.GetRequiredService(builder.DefaultSerializer) : null;
+                return new HybridMessageSerializer(svp.GetRequiredService<ILogger<HybridMessageSerializer>>(), registrationTypes, defaultMessageSerializer);
+            });
+
+            services.AddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<HybridMessageSerializer>());
+        });
+        return mbb;
+    }
+
+    public sealed class HybridSerializerOptionsBuilder : IHybridSerializationBuilder
+    {
+        internal Type DefaultSerializer { get; set; }
+        internal Dictionary<Type, SerializerRegistration> Registrations { get; } = [];
+
+        public IHybridSerializerBuilderOptions RegisterSerializer<TMessageSerializer>(Action<IServiceCollection> services = null) where TMessageSerializer : class, IMessageSerializer
+        {
+            var key = typeof(TMessageSerializer);
+            if (Registrations.TryGetValue(key, out var rawOptions) && rawOptions is SerializerRegistration options)
+            {
+                options.Registration = services;
+                return options;
+            }
+
+            options = new SerializerRegistration(this, typeof(TMessageSerializer), services);
+            Registrations.Add(key, options);
+            return options;
+        }
+
+        internal void SetDefault(Type type, bool status)
+        {
+            if (status)
+            {
+                DefaultSerializer = type;
+                return;
+            }
+
+            if (DefaultSerializer == type)
+            {
+                DefaultSerializer = null;
+            }
+        }
+
+        internal class SerializerRegistration : IHybridSerializerBuilderOptions
+        {
+            private readonly HybridSerializerOptionsBuilder _builder;
+            private readonly Type _type;
+
+            public SerializerRegistration(HybridSerializerOptionsBuilder builder, Type type, Action<IServiceCollection> registration)
+            {
+                this._builder = builder;
+                this._type = type;
+                Registration = registration;
+                Types = [];
+            }
+
+            internal Action<IServiceCollection> Registration { get; set; }
+
+            internal Type[] Types { get; set; }
+
+            public IHybridSerializationBuilder AsDefault()
+            {
+                _builder.SetDefault(_type, true);
+                Types = [];
+                return _builder;
+            }
+
+            public IHybridSerializationBuilder For(params Type[] types)
+            {
+                _builder.SetDefault(_type, false);
+                Types = types;
+                return _builder;
+            }
+        }
     }
 }

--- a/src/SlimMessageBus.Host.Serialization.Hybrid/SlimMessageBus.Host.Serialization.Hybrid.csproj
+++ b/src/SlimMessageBus.Host.Serialization.Hybrid/SlimMessageBus.Host.Serialization.Hybrid.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SlimMessageBus.Host.Serialization.Hybrid.Test" />
+  </ItemGroup>
+
 </Project>

--- a/src/SlimMessageBus.Host.Serialization.Json/MessageBusBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.Json/MessageBusBuilderExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 using SlimMessageBus.Host;
+using SlimMessageBus.Host.Builders;
 
 public static class MessageBusBuilderExtensions
 {
@@ -27,5 +28,20 @@ public static class MessageBusBuilderExtensions
             services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<JsonMessageSerializer>());
         });
         return mbb;
+    }
+
+    /// <summary>
+    /// Registers the <see cref="IMessageSerializer"/> with implementation as <see cref="JsonMessageSerializer"/>.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="encoding">When not provided defaults to <see cref="Encoding.UTF8"></param>
+    /// <param name="jsonSerializerSettings"></param>
+    /// <returns></returns>
+    public static IHybridSerializerBuilderOptions AddJsonSerializer(this IHybridSerializationBuilder builder, Encoding encoding = null, JsonSerializerSettings jsonSerializerSettings = null)
+    {
+        return builder.RegisterSerializer<JsonMessageSerializer>(services =>
+        {
+            services.TryAddSingleton(svp => new JsonMessageSerializer(jsonSerializerSettings ?? svp.GetService<JsonSerializerSettings>(), encoding, svp.GetRequiredService<ILogger<JsonMessageSerializer>>()));
+        });
     }
 }

--- a/src/SlimMessageBus.Host.Serialization.SystemTextJson/MessageBusBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.SystemTextJson/MessageBusBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 using SlimMessageBus.Host;
+using SlimMessageBus.Host.Builders;
 
 public static class MessageBusBuilderExtensions
 {
@@ -22,5 +23,18 @@ public static class MessageBusBuilderExtensions
             services.TryAddSingleton<IMessageSerializer>(svp => svp.GetRequiredService<JsonMessageSerializer>());
         });
         return mbb;
+    }
+
+    /// <summary>
+    /// Registers the <see cref="IMessageSerializer"/> with implementation as <see cref="JsonMessageSerializer"/>.
+    /// </summary>
+    /// <param name="mbb"></param>
+    /// <returns></returns>
+    public static IHybridSerializerBuilderOptions AddJsonSerializer(this IHybridSerializationBuilder builder, JsonSerializerOptions options = null)
+    {
+        return builder.RegisterSerializer<JsonMessageSerializer>(services =>
+        {
+            services.TryAddSingleton(svp => new JsonMessageSerializer(options ?? svp.GetService<JsonSerializerOptions>()));
+        });
     }
 }

--- a/src/SlimMessageBus.sln
+++ b/src/SlimMessageBus.sln
@@ -230,9 +230,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlimMessageBus.Host.RabbitM
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlimMessageBus.Host.RabbitMQ.Test", "Tests\SlimMessageBus.Host.RabbitMQ.Test\SlimMessageBus.Host.RabbitMQ.Test.csproj", "{F5373E1D-A2B4-46CC-9B07-94F6655C8E29}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlimMessageBus.Host.Sql", "SlimMessageBus.Host.Sql\SlimMessageBus.Host.Sql.csproj", "{5EED0E89-2475-40E0-81EF-0F05C9326612}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlimMessageBus.Host.Sql", "SlimMessageBus.Host.Sql\SlimMessageBus.Host.Sql.csproj", "{5EED0E89-2475-40E0-81EF-0F05C9326612}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlimMessageBus.Host.Sql.Common", "SlimMessageBus.Host.Sql.Common\SlimMessageBus.Host.Sql.Common.csproj", "{F19B7A21-7749-465A-8810-4C274A9E8956}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlimMessageBus.Host.Sql.Common", "SlimMessageBus.Host.Sql.Common\SlimMessageBus.Host.Sql.Common.csproj", "{F19B7A21-7749-465A-8810-4C274A9E8956}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlimMessageBus.Host.Serialization.Avro.Test", "Tests\SlimMessageBus.Host.Serialization.Avro.Test\SlimMessageBus.Host.Serialization.Avro.Test.csproj", "{8507237C-68C3-46AD-B7DA-800791C6FDDB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlimMessageBus.Host.Serialization.Hybrid.Test", "Tests\SlimMessageBus.Host.Serialization.Hybrid.Test\SlimMessageBus.Host.Serialization.Hybrid.Test.csproj", "{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -730,6 +734,22 @@ Global
 		{F19B7A21-7749-465A-8810-4C274A9E8956}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F19B7A21-7749-465A-8810-4C274A9E8956}.Release|x86.ActiveCfg = Release|Any CPU
 		{F19B7A21-7749-465A-8810-4C274A9E8956}.Release|x86.Build.0 = Release|Any CPU
+		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Debug|x86.Build.0 = Debug|Any CPU
+		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Release|x86.ActiveCfg = Release|Any CPU
+		{8507237C-68C3-46AD-B7DA-800791C6FDDB}.Release|x86.Build.0 = Release|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Debug|x86.Build.0 = Debug|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Release|x86.ActiveCfg = Release|Any CPU
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -803,6 +823,8 @@ Global
 		{F5373E1D-A2B4-46CC-9B07-94F6655C8E29} = {9F005B5C-A856-4351-8C0C-47A8B785C637}
 		{5EED0E89-2475-40E0-81EF-0F05C9326612} = {9291D340-B4FA-44A3-8060-C14743FB1712}
 		{F19B7A21-7749-465A-8810-4C274A9E8956} = {9291D340-B4FA-44A3-8060-C14743FB1712}
+		{DB624D5F-CB7C-4E16-B1E2-3B368FCB5A46} = {9F005B5C-A856-4351-8C0C-47A8B785C637}
+		{8507237C-68C3-46AD-B7DA-800791C6FDDB} = {9F005B5C-A856-4351-8C0C-47A8B785C637}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {435A0D65-610C-4B84-B1AA-2C7FBE72DB80}

--- a/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/MessageBusBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/MessageBusBuilderExtensionsTests.cs
@@ -1,0 +1,44 @@
+namespace SlimMessageBus.Host.Serialization.Avro.Test;
+
+using SlimMessageBus.Host.Builders;
+
+public class MessageBusBuilderExtensionsTests
+{
+    [Fact]
+    public void When_AddAvroSerializer_Given_Builder_Then_ServicesRegistered()
+    {
+        // arrange
+        var services = new ServiceCollection();
+        var builder = MessageBusBuilder.Create();
+
+        // act
+        builder.AddAvroSerializer();
+
+        // assert
+        builder.PostConfigurationActions.ToList().ForEach(action => action(services));
+
+        services.Should().ContainSingle(x => x.ServiceType == typeof(IMessageSerializer));
+        services.Should().ContainSingle(x => x.ServiceType == typeof(AvroMessageSerializer));
+    }
+
+    [Fact]
+    public void When_AddAvroSerializer_Given_HybridBuilder_Then_ServicesRegistered()
+    {
+        // arrange
+        Action<IServiceCollection> registration = null;
+
+        var services = new ServiceCollection();
+        var mockHybridSerializationBuilder = new Mock<IHybridSerializationBuilder>();
+
+        mockHybridSerializationBuilder.Setup(x => x.RegisterSerializer<AvroMessageSerializer>(It.IsAny<Action<IServiceCollection>>()))
+            .Callback<Action<IServiceCollection>>(x => registration = x);
+
+        // act
+        MessageBusBuilderExtensions.AddAvroSerializer(mockHybridSerializationBuilder.Object);
+        registration?.Invoke(services);
+
+        // assert
+        mockHybridSerializationBuilder.Verify(x => x.RegisterSerializer<AvroMessageSerializer>(It.IsAny<Action<IServiceCollection>>()), Times.Once);
+        services.Should().ContainSingle(x => x.ServiceType == typeof(AvroMessageSerializer));
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/SlimMessageBus.Host.Serialization.Avro.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/SlimMessageBus.Host.Serialization.Avro.Test.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Host.Test.Properties.xml" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.Avro\SlimMessageBus.Host.Serialization.Avro.csproj" />
+  </ItemGroup>
+
+   <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/Usings.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/Usings.cs
@@ -1,6 +1,6 @@
-global using System;
-
 global using FluentAssertions;
+
+global using Microsoft.Extensions.DependencyInjection;
 
 global using Moq;
 

--- a/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/GoogleProtobufMessageSerializerTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/GoogleProtobufMessageSerializerTest.cs
@@ -1,9 +1,8 @@
 ﻿namespace SlimMessageBus.Host.Serialization.GoogleProtobuf.Test;
 
-using FluentAssertions;
-using Microsoft.Extensions.Logging.Abstractions;
 using global::Test;
-using Xunit;
+
+using Microsoft.Extensions.Logging.Abstractions;
 
 public class GoogleProtobufMessageSerializerTest
 {

--- a/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/MessageBusBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/MessageBusBuilderExtensionsTests.cs
@@ -1,0 +1,46 @@
+﻿namespace SlimMessageBus.Host.Serialization.GoogleProtobuf.Test;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using SlimMessageBus.Host.Builders;
+
+public class MessageBusBuilderExtensionsTests
+{
+    [Fact]
+    public void When_AddGoogleProtobufSerializer_Given_Builder_Then_ServicesRegistered()
+    {
+        // arrange
+        var services = new ServiceCollection();
+        var builder = MessageBusBuilder.Create();
+
+        // act
+        builder.AddGoogleProtobufSerializer();
+
+        // assert
+        builder.PostConfigurationActions.ToList().ForEach(action => action(services));
+
+        services.Should().ContainSingle(x => x.ServiceType == typeof(IMessageSerializer));
+        services.Should().ContainSingle(x => x.ServiceType == typeof(GoogleProtobufMessageSerializer));
+    }
+
+    [Fact]
+    public void When_AddGoogleProtobufSerializer_Given_HybridBuilder_Then_ServicesRegistered()
+    {
+        // arrange
+        Action<IServiceCollection> registration = null;
+
+        var services = new ServiceCollection();
+        var mockHybridSerializationBuilder = new Mock<IHybridSerializationBuilder>();
+
+        mockHybridSerializationBuilder.Setup(x => x.RegisterSerializer<GoogleProtobufMessageSerializer>(It.IsAny<Action<IServiceCollection>>()))
+            .Callback<Action<IServiceCollection>>(x => registration = x);
+
+        // act
+        MessageBusBuilderExtensions.AddGoogleProtobufSerializer(mockHybridSerializationBuilder.Object, null);
+        registration?.Invoke(services);
+
+        // assert
+        mockHybridSerializationBuilder.Verify(x => x.RegisterSerializer<GoogleProtobufMessageSerializer>(It.IsAny<Action<IServiceCollection>>()), Times.Once);
+        services.Should().ContainSingle(x => x.ServiceType == typeof(GoogleProtobufMessageSerializer));
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/Usings.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/Usings.cs
@@ -1,5 +1,3 @@
-global using System;
-
 global using FluentAssertions;
 
 global using Moq;

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/Helpers/SampleMessages.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/Helpers/SampleMessages.cs
@@ -1,0 +1,5 @@
+﻿namespace SlimMessageBus.Host.Serialization.Hybrid.Test.Helpers;
+
+public record SampleOne;
+public record SampleTwo;
+public record SampleThree;

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/HybridMessageSerializerTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/HybridMessageSerializerTests.cs
@@ -1,0 +1,103 @@
+﻿namespace SlimMessageBus.Host.Serialization.Hybrid.Test
+{
+
+    public class HybridMessageSerializerTests
+    {
+        [Fact]
+        public void When_ConstructorReceivesARepeatedDefinition_Then_ThrowException()
+        {
+            // arrange
+            var mockDefaultSerializer = new Mock<IMessageSerializer>();
+            var mockSerializer1 = new Mock<IMessageSerializer>();
+            var mockSerializer2 = new Mock<IMessageSerializer>();
+            var mockLogger = new Mock<ILogger<HybridMessageSerializer>>();
+
+            var serializers = new Dictionary<IMessageSerializer, Type[]>
+            {
+                { mockSerializer1.Object, new[] { typeof(SampleOne), typeof(SampleTwo) } },
+                { mockSerializer2.Object, new[] { typeof(SampleOne) } },
+            };
+
+            // act
+            var act = () => new HybridMessageSerializer(mockLogger.Object, serializers, mockDefaultSerializer.Object);
+
+            // assert
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void When_NoDefaultSerializerIsSupplied_Then_UseFirstSpecialist()
+        {
+            // arrange
+            var mockDefaultSerializer = new Mock<IMessageSerializer>();
+            var mockSerializer1 = new Mock<IMessageSerializer>();
+            var mockLogger = new Mock<ILogger<HybridMessageSerializer>>();
+
+            var serializers = new Dictionary<IMessageSerializer, Type[]>
+            {
+                { mockDefaultSerializer.Object, new[] { typeof(SampleOne) } },
+                { mockSerializer1.Object, new[] { typeof(SampleTwo) } },
+            };
+
+            // act
+            var target = new HybridMessageSerializer(mockLogger.Object, serializers, default);
+            var actual = target.DefaultSerializer;
+
+            // assert
+            actual.Should().BeEquivalentTo(mockDefaultSerializer.Object);
+        }
+
+        [Fact]
+        public void When_ASpecialisedMessageIsSerialized_Then_UseSpecializedSerializer()
+        {
+            // arrange
+            var mockDefaultSerializer = new Mock<IMessageSerializer>();
+
+            var mockSerializer1 = new Mock<IMessageSerializer>();
+            mockSerializer1.Setup(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>())).Verifiable(Times.Once());
+
+            var mockSerializer2 = new Mock<IMessageSerializer>();
+
+            var mockLogger = new Mock<ILogger<HybridMessageSerializer>>();
+            var serializers = new Dictionary<IMessageSerializer, Type[]>
+            {
+                { mockSerializer1.Object, new[] { typeof(SampleOne) } },
+                { mockSerializer2.Object, new[] { typeof(SampleTwo) } },
+            };
+
+            // act
+            var target = new HybridMessageSerializer(mockLogger.Object, serializers, mockDefaultSerializer.Object);
+            var _ = target.Serialize(typeof(SampleOne), new SampleOne());
+
+            // assert
+            mockSerializer1.Verify(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>()));
+            mockSerializer2.VerifyNoOtherCalls();
+            mockDefaultSerializer.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void When_AGenericMessageIsSerialized_Then_UseDefaultSerializer()
+        {
+            // arrange
+            var mockDefaultSerializer = new Mock<IMessageSerializer>();
+            mockDefaultSerializer.Setup(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>())).Verifiable(Times.Once());
+
+            var mockSerializer1 = new Mock<IMessageSerializer>();
+
+            var mockLogger = new Mock<ILogger<HybridMessageSerializer>>();
+            var serializers = new Dictionary<IMessageSerializer, Type[]>
+            {
+                { mockSerializer1.Object, new[] { typeof(SampleTwo) } }
+            };
+
+            // act
+            var target = new HybridMessageSerializer(mockLogger.Object, serializers, mockDefaultSerializer.Object);
+            var _ = target.Serialize(typeof(SampleOne), new SampleOne());
+
+            // assert
+            mockDefaultSerializer.Verify(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>()));
+            mockSerializer1.VerifyNoOtherCalls();
+        }
+    }
+}
+

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/MessageBusBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/MessageBusBuilderExtensionsTests.cs
@@ -1,0 +1,86 @@
+namespace SlimMessageBus.Host.Serialization.Hybrid.Test;
+
+using Microsoft.Extensions.DependencyInjection;
+
+public class MessageBusBuilderExtensionsTests
+{
+    private readonly IServiceCollection _services;
+
+    public MessageBusBuilderExtensionsTests()
+    {
+        // arrange
+        var mockLogger = new Mock<ILogger<HybridMessageSerializer>>();
+
+        _services = new ServiceCollection();
+        _services.AddSingleton(mockLogger.Object);
+
+        // act
+        _services.AddSlimMessageBus(cfg =>
+        {
+            cfg.AddHybridSerializer(builder =>
+            {
+                builder
+                    .RegisterSerializer<SerializerOne>(services => services.AddSingleton<SerializerOne>())
+                    .AsDefault();
+
+                builder
+                    .RegisterSerializer<SerializerTwo>(services => services.AddSingleton<SerializerTwo>())
+                    .For(typeof(SampleTwo));
+
+                builder
+                    .RegisterSerializer<SerializerThree>(services => services.AddSingleton<SerializerThree>())
+                    .For(typeof(SampleThree));
+            });
+        });
+    }
+
+    [Fact]
+    public void When_IMessageSerializerRegistrationsAlreadyExist_Then_RemovePreviousRegistrations()
+    {
+        // assert
+        _services.Count(x => x.ServiceType == typeof(IMessageSerializer)).Should().Be(1);
+    }
+
+    [Fact]
+    public void When_HybridMessageSerializerIsAdded_Then_RegisterAsIMessageSerializer()
+    {
+        // act
+        var serviceProvider = _services.BuildServiceProvider();
+        var target = serviceProvider.GetServices<IMessageSerializer>().ToList();
+
+        // assert
+        target.Count.Should().Be(1);
+        target.Single().GetType().Should().Be(typeof(HybridMessageSerializer));
+    }
+
+    [Fact]
+    public void When_HybridMessageSerializerIsAdded_Then_SerializersAndTypesShouldConfigured()
+    {
+        // act
+        var serviceProvider = _services.BuildServiceProvider();
+        var target = serviceProvider.GetService<HybridMessageSerializer>();
+
+        // assert
+        target.DefaultSerializer.GetType().Should().Be(typeof(SerializerOne));
+        target.SerializerByType.Count.Should().Be(2);
+        target.SerializerByType.Should().ContainKey(typeof(SampleTwo)).WhoseValue.Should().BeOfType<SerializerTwo>();
+        target.SerializerByType.Should().ContainKey(typeof(SampleThree)).WhoseValue.Should().BeOfType<SerializerThree>();
+    }
+
+    public abstract class AbstractSerializer : IMessageSerializer
+    {
+        public object Deserialize(Type t, byte[] payload)
+        {
+            throw new NotImplementedException();
+        }
+
+        public byte[] Serialize(Type t, object message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class SerializerOne : AbstractSerializer { }
+    public class SerializerTwo : AbstractSerializer { }
+    public class SerializerThree : AbstractSerializer { }
+}

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SlimMessageBus.Host.Serialization.Hybrid.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SlimMessageBus.Host.Serialization.Hybrid.Test.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../Host.Test.Properties.xml" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.Hybrid\SlimMessageBus.Host.Serialization.Hybrid.csproj" />
+    <ProjectReference Include="..\..\SlimMessageBus.Host\SlimMessageBus.Host.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/Usings.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/Usings.cs
@@ -1,0 +1,9 @@
+global using FluentAssertions;
+
+global using Microsoft.Extensions.Logging;
+
+global using Moq;
+
+global using SlimMessageBus.Host.Serialization.Hybrid.Test.Helpers;
+
+global using Xunit;

--- a/src/Tests/SlimMessageBus.Host.Serialization.Json.Test/MessageBusBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Json.Test/MessageBusBuilderExtensionsTests.cs
@@ -1,0 +1,46 @@
+﻿namespace SlimMessageBus.Host.Serialization.Json.Test;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using SlimMessageBus.Host.Builders;
+
+public class MessageBusBuilderExtensionsTests
+{
+    [Fact]
+    public void When_AddJsonSerializer_Given_Builder_Then_ServicesRegistered()
+    {
+        // arrange
+        var services = new ServiceCollection();
+        var builder = MessageBusBuilder.Create();
+
+        // act
+        builder.AddJsonSerializer();
+
+        // assert
+        builder.PostConfigurationActions.ToList().ForEach(action => action(services));
+
+        services.Should().ContainSingle(x => x.ServiceType == typeof(IMessageSerializer));
+        services.Should().ContainSingle(x => x.ServiceType == typeof(JsonMessageSerializer));
+    }
+
+    [Fact]
+    public void When_AddJsonSerializer_Given_HybridBuilder_Then_ServicesRegistered()
+    {
+        // arrange
+        Action<IServiceCollection> registration = null;
+
+        var services = new ServiceCollection();
+        var mockHybridSerializationBuilder = new Mock<IHybridSerializationBuilder>();
+
+        mockHybridSerializationBuilder.Setup(x => x.RegisterSerializer<JsonMessageSerializer>(It.IsAny<Action<IServiceCollection>>()))
+            .Callback<Action<IServiceCollection>>(x => registration = x);
+
+        // act
+        MessageBusBuilderExtensions.AddJsonSerializer(mockHybridSerializationBuilder.Object, null);
+        registration?.Invoke(services);
+
+        // assert
+        mockHybridSerializationBuilder.Verify(x => x.RegisterSerializer<JsonMessageSerializer>(It.IsAny<Action<IServiceCollection>>()), Times.Once);
+        services.Should().ContainSingle(x => x.ServiceType == typeof(JsonMessageSerializer));
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Serialization.Json.Test/SlimMessageBus.Host.Serialization.Json.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Json.Test/SlimMessageBus.Host.Serialization.Json.Test.csproj
@@ -3,6 +3,10 @@
   <Import Project="../Host.Test.Properties.xml" />
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.Json\SlimMessageBus.Host.Serialization.Json.csproj" />
   </ItemGroup>
 

--- a/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/MessageBusBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/MessageBusBuilderExtensionsTests.cs
@@ -1,0 +1,47 @@
+﻿namespace SlimMessageBus.Host.Serialization.SystemTextJson.Test;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using SlimMessageBus.Host.Builders;
+using SlimMessageBus.Host.Serialization.SystemTextJson;
+
+public class MessageBusBuilderExtensionsTests
+{
+    [Fact]
+    public void When_AddJsonSerializer_Given_Builder_Then_ServicesRegistered()
+    {
+        // arrange
+        var services = new ServiceCollection();
+        var builder = MessageBusBuilder.Create();
+
+        // act
+        builder.AddJsonSerializer();
+
+        // assert
+        builder.PostConfigurationActions.ToList().ForEach(action => action(services));
+
+        services.Should().ContainSingle(x => x.ServiceType == typeof(IMessageSerializer));
+        services.Should().ContainSingle(x => x.ServiceType == typeof(JsonMessageSerializer));
+    }
+
+    [Fact]
+    public void When_AddJsonSerializer_Given_HybridBuilder_Then_ServicesRegistered()
+    {
+        // arrange
+        Action<IServiceCollection> registration = null;
+
+        var services = new ServiceCollection();
+        var mockHybridSerializationBuilder = new Mock<IHybridSerializationBuilder>();
+
+        mockHybridSerializationBuilder.Setup(x => x.RegisterSerializer<JsonMessageSerializer>(It.IsAny<Action<IServiceCollection>>()))
+            .Callback<Action<IServiceCollection>>(x => registration = x);
+
+        // act
+        MessageBusBuilderExtensions.AddJsonSerializer(mockHybridSerializationBuilder.Object, null);
+        registration?.Invoke(services);
+
+        // assert
+        mockHybridSerializationBuilder.Verify(x => x.RegisterSerializer<JsonMessageSerializer>(It.IsAny<Action<IServiceCollection>>()), Times.Once);
+        services.Should().ContainSingle(x => x.ServiceType == typeof(JsonMessageSerializer));
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/SlimMessageBus.Host.Serialization.SystemTextJson.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/SlimMessageBus.Host.Serialization.SystemTextJson.Test.csproj
@@ -3,6 +3,10 @@
   <Import Project="../Host.Test.Properties.xml" />
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.SystemTextJson\SlimMessageBus.Host.Serialization.SystemTextJson.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
As discussed in #238, here is an alternative implementation based on specialised builders for the hybrid message serializer.

As with all things, there are a few pros and cons

### Pros:
* Implementation does not manipulate the DI which should result in no hidden surprises
* Builder code maintenance should be simpler (far simpler code required)
* Easier to add custom (unpackaged) registrations (can also exclude action is registered with container elsewhere)
```cs
builder
    .RegisterSerializer<SerializerTwo>(services => services.AddSingleton<SerializerTwo>())
    .For(typeof(SampleTwo));
```
* No potential runtime exceptions due to state of builder not being as expected (won't compile on a misplaced `.For()`)
* Intellisense shows what's available and nothing else
![image](https://github.com/zarusz/SlimMessageBus/assets/1317506/1cadfcb0-9ecd-4b26-800f-f6db0f553e5a)

### Cons:
* The hybrid message serializer becomes a special implementation requiring its own interfaces and implementation in other  (unrelated) serializers
* Functionality needs an extra extension method to be added when adding a message serializer (old one remains, so it won't be a breaking change though)
![image](https://github.com/zarusz/SlimMessageBus/assets/1317506/1af18650-5a9b-475a-84ec-fb2e1d0391ec)
