### PR TITLE
#254: Do not delete default rule if no other rule exists

### DIFF
--- a/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusTopologyService.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusTopologyService.cs
@@ -246,7 +246,9 @@ public class ServiceBusTopologyService
 
                             if ((subscriptionStatus & TopologyCreationStatus.Exists) != 0)
                             {
-                                if ((subscriptionStatus & TopologyCreationStatus.Created) != 0 && topologyProvisioning.CanConsumerCreateSubscriptionFilter)
+                                if ((subscriptionStatus & TopologyCreationStatus.Created) != 0 
+                                    && topologyProvisioning.CanConsumerCreateSubscriptionFilter 
+                                    && consumerSettingsGroup.Any(x => x.GetRules()?.Count > 0))
                                 {
                                     // Note: for a newly created subscription, ASB creates a default filter automatically, we need to remove it and let the user defined rules take over
                                     await _adminClient.DeleteRuleAsync(path, subscriptionName, RuleProperties.DefaultRuleName);


### PR DESCRIPTION
Bug in #245 resulted in the default rule of a subscription being deleted on creation regardless as to where there was a rule to replace it or not.

PR returns to the original flow where the default rule will only be deleted if the subscription has just been created and there are alternate rules to apply.