### PR TITLE
[Host] Dispose message if required

### DIFF
--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/ConcurrencyIncreasingMessageProcessorDecorator.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/ConcurrencyIncreasingMessageProcessorDecorator.cs
@@ -53,7 +53,7 @@ public sealed class ConcurrencyIncreasingMessageProcessorDecorator<TMessage> : I
         {
             // report the last exception
             _lastException = null;
-            return new(e, _lastExceptionSettings, null, _lastExceptionMessage);
+            return new(e, _lastExceptionSettings, null);
         }
 
         Interlocked.Increment(ref _pendingCount);
@@ -62,7 +62,7 @@ public sealed class ConcurrencyIncreasingMessageProcessorDecorator<TMessage> : I
         _ = ProcessInBackground(transportMessage, messageHeaders, currentServiceProvider, consumerContextProperties, cancellationToken);
 
         // Not exception - we don't know yet
-        return new(null, null, null, null);
+        return new(null, null, null);
     }
 
     public TMessage GetMessageWithException()

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/IMessageProcessor.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/IMessageProcessor.cs
@@ -1,11 +1,10 @@
 namespace SlimMessageBus.Host;
 
-public readonly struct ProcessMessageResult(Exception exception, AbstractConsumerSettings consumerSettings, object response, object message)
+public readonly struct ProcessMessageResult(Exception exception, AbstractConsumerSettings consumerSettings, object response)
 {
     public Exception Exception { get; init; } = exception;
     public AbstractConsumerSettings ConsumerSettings { get; init; } = consumerSettings;
     public object Response { get; init; } = response;
-    public object Message { get; init; } = message;
 }
 
 public interface IMessageProcessor<in TMessage>
@@ -15,6 +14,6 @@ public interface IMessageProcessor<in TMessage>
     /// <summary>
     /// Processes the arrived message
     /// </summary>
-    /// <returns>Null, if message processing was sucessful, otherwise the Exception</returns>
+    /// <returns>Null, if message processing was successful, otherwise the Exception</returns>
     Task<ProcessMessageResult> ProcessMessage(TMessage transportMessage, IReadOnlyDictionary<string, object> messageHeaders, IDictionary<string, object> consumerContextProperties = null, IServiceProvider currentServiceProvider = null, CancellationToken cancellationToken = default);
 }

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/ResponseMessageProcessor.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/ResponseMessageProcessor.cs
@@ -31,14 +31,14 @@ public class ResponseMessageProcessor<TMessage> : IMessageProcessor<TMessage>
         {
             var messagePayload = _messagePayloadProvider(transportMessage);
             var exception = await _responseConsumer.OnResponseArrived(messagePayload, _requestResponseSettings.Path, messageHeaders);
-            return new(exception, _requestResponseSettings, null, transportMessage);
+            return new(exception, _requestResponseSettings, null);
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Error occured while consuming response message, {Message}", transportMessage);
+            _logger.LogError(e, "Error occurred while consuming response message, {Message}", transportMessage);
 
             // We can only continue and process all messages in the lease    
-            return new(e, _requestResponseSettings, null, transportMessage);
+            return new(e, _requestResponseSettings, null);
         }
     }
 }

--- a/src/Tests/SlimMessageBus.Host.Memory.Test/Consumers/ConcurrentMessageProcessorQueueTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Memory.Test/Consumers/ConcurrentMessageProcessorQueueTests.cs
@@ -20,7 +20,7 @@ public class ConcurrentMessageProcessorQueueTests
         static async Task<ProcessMessageResult> ProcessMessageFake(object transportMessage, IReadOnlyDictionary<string, object> messageHeaders, IDictionary<string, object> consumerContextProperties, IServiceProvider currentServiceProvider, CancellationToken cancellationToken)
         {
             await Task.Delay(500, cancellationToken);
-            return new ProcessMessageResult(null, null, null, null);
+            return new ProcessMessageResult(null, null, null);
         }
 
         messageProcessor

--- a/src/Tests/SlimMessageBus.Host.Memory.Test/Consumers/MessageProcessorQueueTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Memory.Test/Consumers/MessageProcessorQueueTests.cs
@@ -18,7 +18,7 @@ public class MessageProcessorQueueTests
         static async Task<ProcessMessageResult> ProcessMessageFake(object transportMessage, IReadOnlyDictionary<string, object> messageHeaders, IDictionary<string, object> consumerContextProperties, IServiceProvider currentServiceProvider, CancellationToken cancellationToken)
         {
             await Task.Delay(500, cancellationToken);
-            return new ProcessMessageResult(null, null, null, null);
+            return new ProcessMessageResult(null, null, null);
         }
 
         messageProcessor

--- a/src/Tests/SlimMessageBus.Host.Test/Consumer/ConcurrencyIncreasingMessageProcessorDecoratorTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Consumer/ConcurrencyIncreasingMessageProcessorDecoratorTest.cs
@@ -15,7 +15,7 @@ public class ConcurrencyIncreasingMessageProcessorDecoratorTest
     [Theory]
     [InlineData(10, 40)]
     [InlineData(2, 40)]
-    public async Task When_ProcessMessage_Given_NMessagesAndConcurrencySetToC_Then_NMethodInvokationsHappenOnTargetWithCConcurrently(int concurrency, int expectedMessageCount)
+    public async Task When_ProcessMessage_Given_NMessagesAndConcurrencySetToC_Then_NMethodInvocationsHappenOnTargetWithCConcurrently(int concurrency, int expectedMessageCount)
     {
         // arrange
         _subject = new ConcurrencyIncreasingMessageProcessorDecorator<SomeMessage>(concurrency, _busMock.Bus, _messageProcessorMock.Object);
@@ -50,7 +50,7 @@ public class ConcurrencyIncreasingMessageProcessorDecoratorTest
 
                 // Leaving critical section
                 Interlocked.Decrement(ref currentSectionCount);
-                return new(null, null, null, null);
+                return new(null, null, null);
             });
 
         // act


### PR DESCRIPTION
Fixes #256 by disposing a message (if required) once `MessageProcessor<TTransportMessage>.ProcessMessage` has completed the pipeline.

**Please note** that in order for `ProcessMessage` to retain ownership of the `message` object, it can no longer return the `message` object as part of `ProcessMessageResult`. The `Message` property in `ProcessMessageResult` has therefore been removed.