### PR TITLE
[Host.Outbox] Ensure SQL tables are provisioned and baseline test

### DIFF
--- a/infrastructure.ps1
+++ b/infrastructure.ps1
@@ -1,0 +1,1 @@
+docker compose -f src/Infrastructure/docker-compose.yml up --force-recreate -V

--- a/src/Host.Plugin.Properties.xml
+++ b/src/Host.Plugin.Properties.xml
@@ -4,7 +4,7 @@
 	<Import Project="Common.NuGet.Properties.xml" />
 
 	<PropertyGroup>
-    <Version>2.3.5</Version>
+    <Version>2.4.0-rc1</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/Infrastructure/README.md
+++ b/src/Infrastructure/README.md
@@ -8,10 +8,16 @@ No volumes have been configured so as to provide clean instances on each run.
 src/Infrastructure> docker compose up --force-recreate -V
 ```
 
-or
+or Unix
 
 ```
 > ./infrastructure.sh
+```
+
+or Windows
+
+```
+> .\infrastructure.ps1
 ```
 
 ## Configuration
@@ -26,7 +32,7 @@ Personal instances of Azure resources are required as containers are not availab
 
 ### Azure Event Hub
 
-The transport/plug-in does not provide topology provisioning (just yet).
+The transport/plug-in does not provide topology provisioning ([just yet](https://github.com/zarusz/SlimMessageBus/issues/111)).
 The below event hubs and consumer groups will need to be manually added to the Azure Event Hub instance for the integration tests to run.
 
 | Event Hub      | Consumer Group  |

--- a/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusMessageBus.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusMessageBus.cs
@@ -109,7 +109,7 @@ public class ServiceBusMessageBus : MessageBusBase<ServiceBusMessageBusSettings>
                 responseConsumer: this,
                 messagePayloadProvider: m => m.Body.ToArray());
 
-            AddConsumerFrom(topicSubscription, messageProcessor, new[] { Settings.RequestResponse });
+            AddConsumerFrom(topicSubscription, messageProcessor, [Settings.RequestResponse]);
         }
     }
 

--- a/src/SlimMessageBus.Host.Interceptor/Bus/MessageBusLifecycleEventType.cs
+++ b/src/SlimMessageBus.Host.Interceptor/Bus/MessageBusLifecycleEventType.cs
@@ -2,8 +2,13 @@
 
 public enum MessageBusLifecycleEventType
 {
+    /// <summary>
+    /// Invoked when the master bus is created.
+    /// Can be used to initalize any resource before the messages are produced or consumed.
+    /// </summary>
+    Created,
     Starting,
     Started,
     Stopping,
-    Stopped,
+    Stopped
 }

--- a/src/SlimMessageBus.Host/MessageBusBase.cs
+++ b/src/SlimMessageBus.Host/MessageBusBase.cs
@@ -146,6 +146,10 @@ public abstract class MessageBusBase : IDisposable, IAsyncDisposable, IMasterMes
 
         Build();
 
+        // Notify the bus has been created - before any message can be produced
+        AddInit(OnBusLifecycle(MessageBusLifecycleEventType.Created));
+
+        // Auto start consumers if enabled
         if (Settings.AutoStartConsumers)
         {
             // Fire and forget start
@@ -196,7 +200,7 @@ public abstract class MessageBusBase : IDisposable, IAsyncDisposable, IMasterMes
 
     private async Task OnBusLifecycle(MessageBusLifecycleEventType eventType)
     {
-        _lifecycleInterceptors ??= Settings.ServiceProvider?.GetService<IEnumerable<IMessageBusLifecycleInterceptor>>();
+        _lifecycleInterceptors ??= Settings.ServiceProvider?.GetServices<IMessageBusLifecycleInterceptor>();
         if (_lifecycleInterceptors != null)
         {
             foreach (var i in _lifecycleInterceptors)

--- a/src/SlimMessageBus.sln
+++ b/src/SlimMessageBus.sln
@@ -241,9 +241,19 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Infrastructure", "Infrastructure", "{137BFD32-CD0A-47CA-8884-209CD49DEE8C}"
 	ProjectSection(SolutionItems) = preProject
 		Infrastructure\docker-compose.yml = Infrastructure\docker-compose.yml
+		..\infrastructure.ps1 = ..\infrastructure.ps1
 		..\infrastructure.sh = ..\infrastructure.sh
 		Infrastructure\mosquitto.conf = Infrastructure\mosquitto.conf
 		Infrastructure\README.md = Infrastructure\README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{1A71BB05-58ED-4B27-B4A4-A03D9E608C1C}"
+	ProjectSection(SolutionItems) = preProject
+		..\build\do_build.ps1 = ..\build\do_build.ps1
+		..\build\do_package.ps1 = ..\build\do_package.ps1
+		..\build\do_test.ps1 = ..\build\do_test.ps1
+		..\build\do_test_ci.ps1 = ..\build\do_test_ci.ps1
+		..\build\tasks.ps1 = ..\build\tasks.ps1
 	EndProjectSection
 EndProject
 Global

--- a/src/Tests/SlimMessageBus.Host.AzureServiceBus.Test/ServiceBusMessageBusTests.cs
+++ b/src/Tests/SlimMessageBus.Host.AzureServiceBus.Test/ServiceBusMessageBusTests.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using Azure.Messaging.ServiceBus;
 
 using SlimMessageBus.Host;
+using SlimMessageBus.Host.Interceptor;
 using SlimMessageBus.Host.Serialization;
 
 public class ServiceBusMessageBusTests : IDisposable
@@ -22,6 +23,7 @@ public class ServiceBusMessageBusTests : IDisposable
         serviceProviderMock.Setup(x => x.GetService(It.Is<Type>(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>)))).Returns(Enumerable.Empty<object>());
         serviceProviderMock.Setup(x => x.GetService(typeof(IMessageSerializer))).Returns(new Mock<IMessageSerializer>().Object);
         serviceProviderMock.Setup(x => x.GetService(typeof(IMessageTypeResolver))).Returns(new AssemblyQualifiedNameMessageTypeResolver());
+        serviceProviderMock.Setup(x => x.GetService(typeof(IEnumerable<IMessageBusLifecycleInterceptor>))).Returns(Array.Empty<IMessageBusLifecycleInterceptor>());
 
         BusBuilder.WithDependencyResolver(serviceProviderMock.Object);
 

--- a/src/Tests/SlimMessageBus.Host.Integration.Test/HybridTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Integration.Test/HybridTests.cs
@@ -78,11 +78,12 @@ public class HybridTests : IDisposable
             var topic = "integration-external-message";
             mbb
                 .Produce<ExternalMessage>(x => x.DefaultTopic(topic))
-                .Consume<ExternalMessage>(x => x.Topic(topic))
+                .Consume<ExternalMessage>(x => x.Topic(topic).Instances(20))
                 .WithProviderServiceBus(cfg =>
                 {
                     cfg.SubscriptionName("test");
                     cfg.ConnectionString = Secrets.Service.PopulateSecrets(_configuration["Azure:ServiceBus"]);
+                    cfg.PrefetchCount = 100;
                 });
         });
     }

--- a/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/BusType.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/BusType.cs
@@ -1,0 +1,7 @@
+﻿namespace SlimMessageBus.Host.Outbox.DbContext.Test;
+
+public enum BusType
+{
+    AzureSB,
+    Kafka,
+}

--- a/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/DatabaseFacadeExtenstions.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/DatabaseFacadeExtenstions.cs
@@ -1,0 +1,19 @@
+﻿namespace SlimMessageBus.Host.Outbox.DbContext.Test;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+public static class DatabaseFacadeExtenstions
+{
+    public static Task EraseTableIfExists(this DatabaseFacade db, string tableName)
+    {
+#pragma warning disable EF1002 // Risk of vulnerability to SQL injection.
+        return db.ExecuteSqlRawAsync($"""
+            IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND TABLE_NAME = '{tableName}')
+            BEGIN
+                DELETE FROM dbo.{tableName};
+            END
+            """);
+#pragma warning restore EF1002 // Risk of vulnerability to SQL injection.
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/OutboxBenchmarkTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/OutboxBenchmarkTests.cs
@@ -1,0 +1,139 @@
+﻿namespace SlimMessageBus.Host.Outbox.DbContext.Test;
+
+/// <summary>
+/// This test should help to understand the runtime performance and overhead of the outbox feature.
+/// It will generate the time measurements for a given transport (Azure DB + Azure SQL instance) as the baseline, 
+/// and then measure times when outbox is enabled. 
+/// This should help asses the overhead of outbox and to baseline future outbox improvements.
+/// </summary>
+/// <param name="testOutputHelper"></param>
+[Trait("Category", "Integration")] // for benchmarks
+public class OutboxBenchmarkTests(ITestOutputHelper testOutputHelper) : BaseIntegrationTest<OutboxBenchmarkTests>(testOutputHelper)
+{
+    private static readonly string OutboxTableName = "IntTest_Benchmark_Outbox";
+    private static readonly string MigrationsTableName = "IntTest_Benchmark_Migrations";
+
+    private bool _useOutbox;
+
+    protected override void SetupServices(ServiceCollection services, IConfigurationRoot configuration)
+    {
+        services.AddSlimMessageBus(mbb =>
+        {
+            mbb.AddChildBus("ExternalBus", mbb =>
+            {
+                var topic = "tests.outbox-benchmark/customer-events";
+                mbb
+                    .WithProviderServiceBus(cfg =>
+                    {
+                        cfg.ConnectionString = Secrets.Service.PopulateSecrets(configuration["Azure:ServiceBus"]);
+                        cfg.PrefetchCount = 100; // fetch 100 messages at a time
+                    })
+                    .Produce<CustomerCreatedEvent>(x => x.DefaultTopic(topic))
+                    .Consume<CustomerCreatedEvent>(x => x
+                        .Topic(topic)
+                        .WithConsumer<CustomerCreatedEventConsumer>()
+                        .Instances(20) // process messages in parallel
+                        .SubscriptionName(nameof(OutboxBenchmarkTests))); // for AzureSB
+
+                if (_useOutbox)
+                {
+                    mbb
+                        .UseOutbox(); // All outgoing messages from this bus will go out via an outbox
+                }
+            });
+            mbb.AddServicesFromAssembly(Assembly.GetExecutingAssembly());
+            mbb.AddJsonSerializer();
+            mbb.AddOutboxUsingDbContext<CustomerContext>(opts =>
+            {
+                opts.PollBatchSize = 100;
+                opts.PollIdleSleep = TimeSpan.FromSeconds(0.5);
+                opts.MessageCleanup.Interval = TimeSpan.FromSeconds(10);
+                opts.MessageCleanup.Age = TimeSpan.FromMinutes(1);
+                opts.SqlSettings.DatabaseTableName = OutboxTableName;
+                opts.SqlSettings.DatabaseMigrationsTableName = MigrationsTableName;
+            });
+            mbb.AutoStartConsumersEnabled(false);
+        });
+
+        services.AddSingleton<TestEventCollector<CustomerCreatedEvent>>();
+
+        // Entity Framework setup - application specific EF DbContext
+        services.AddDbContext<CustomerContext>(options => options.UseSqlServer(Secrets.Service.PopulateSecrets(Configuration.GetConnectionString("DefaultConnection"))));
+    }
+
+    private async Task PerformDbOperation(Func<CustomerContext, Task> action)
+    {
+        using var scope = ServiceProvider!.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<CustomerContext>();
+        await action(context);
+    }
+
+    [Theory]
+    [InlineData([true, 1000])] // compare with outbox
+    [InlineData([false, 1000])] // vs. without outbox
+    public async Task Given_EventPublisherAndConsumerUsingOutbox_When_BurstOfEventsIsSent_Then_EventsAreConsumedProperly(bool useOutbox, int messageCount)
+    {
+        // arrange
+        _useOutbox = useOutbox;
+
+        await PerformDbOperation(async context =>
+        {
+            // migrate db
+            await context.Database.MigrateAsync();
+
+            // clean outbox from previous test run
+            await context.Database.EraseTableIfExists(OutboxTableName);
+            await context.Database.EraseTableIfExists(MigrationsTableName);
+        });
+
+        var surnames = new[] { "Doe", "Smith", "Kowalsky" };
+        var events = Enumerable.Range(0, messageCount).Select(x => new CustomerCreatedEvent(Guid.NewGuid(), $"John {x:000}", surnames[x % surnames.Length])).ToList();
+        var store = ServiceProvider!.GetRequiredService<TestEventCollector<CustomerCreatedEvent>>();
+
+        // act
+
+        // publish the events in one shot (consumers are not started yet)
+        var publishTimer = Stopwatch.StartNew();
+
+        var publishTasks = events
+            .Select(async ev =>
+            {
+                var unitOfWorkScope = ServiceProvider!.CreateScope();
+                await using (unitOfWorkScope as IAsyncDisposable)
+                {
+                    var bus = unitOfWorkScope.ServiceProvider.GetRequiredService<IMessageBus>();
+                    try
+                    {
+                        await bus.Publish(ev, headers: new Dictionary<string, object> { ["CustomerId"] = ev.Id });
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogInformation("Exception occurred while publishing event {Event}: {Message}", ev, ex.Message);
+                    }
+                }
+            })
+            .ToArray();
+
+        await Task.WhenAll(publishTasks);
+
+        var publishTimerElapsed = publishTimer.Elapsed;
+
+        // start consumers
+        await EnsureConsumersStarted();
+
+        // consume the events from outbox
+        var consumptionTimer = Stopwatch.StartNew();
+        await store.WaitUntilArriving(newMessagesTimeout: 5, expectedCount: events.Count);
+
+        // assert
+
+        var consumeTimerElapsed = consumptionTimer.Elapsed;
+
+        // Log the measured times
+        Logger.LogInformation("Message Publish took: {Elapsed}", publishTimerElapsed);
+        Logger.LogInformation("Message Consume took: {Elapsed}", consumeTimerElapsed);
+
+        // Ensure the expected number of events was actually published to ASB and delivered via that channel.
+        store.Count.Should().Be(events.Count);
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/TransactionType.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/TransactionType.cs
@@ -1,0 +1,7 @@
+﻿namespace SlimMessageBus.Host.Outbox.DbContext.Test;
+
+public enum TransactionType
+{
+    SqlTransaction,
+    TarnsactionScope
+}

--- a/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/Usings.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.DbContext.Test/Usings.cs
@@ -1,3 +1,24 @@
+global using System.Diagnostics;
+global using System.Reflection;
+
+global using Confluent.Kafka;
+
+global using FluentAssertions;
+
+global using Microsoft.EntityFrameworkCore;
+global using Microsoft.Extensions.Configuration;
+global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Logging;
+
+global using SecretStore;
+
+global using SlimMessageBus.Host.AzureServiceBus;
+global using SlimMessageBus.Host.Kafka;
+global using SlimMessageBus.Host.Memory;
+global using SlimMessageBus.Host.Outbox.DbContext.Test.DataAccess;
+global using SlimMessageBus.Host.Outbox.Sql;
+global using SlimMessageBus.Host.Serialization.SystemTextJson;
+global using SlimMessageBus.Host.Test.Common.IntegrationTest;
+
 global using Xunit;
 global using Xunit.Abstractions;
-global using FluentAssertions;

--- a/src/Tests/SlimMessageBus.Host.Test.Common/IntegrationTest/BaseIntegrationTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test.Common/IntegrationTest/BaseIntegrationTest.cs
@@ -83,7 +83,7 @@ public abstract class BaseIntegrationTest<T> : IAsyncLifetime
         var consumerControl = ServiceProvider.GetRequiredService<IConsumerControl>();
 
         // ensure the consumers are warm
-        while (!consumerControl.IsStarted && timeout.ElapsedMilliseconds < 5000) await Task.Delay(200);
+        while (!consumerControl.IsStarted && timeout.ElapsedMilliseconds < 5000) await Task.Delay(100);
     }
 
     public Task InitializeAsync()

--- a/src/Tests/SlimMessageBus.Host.Test.Common/MoqExtensions.cs
+++ b/src/Tests/SlimMessageBus.Host.Test.Common/MoqExtensions.cs
@@ -1,0 +1,31 @@
+﻿namespace SlimMessageBus.Host.Test.Common;
+
+using System.Diagnostics;
+using System.Linq.Expressions;
+
+public static class MoqExtensions
+{
+    public static async Task VerifyWithRetry<T, TResult>(this Mock<T> mock, TimeSpan timeout, Expression<Func<T, TResult>> expression, Times times)
+        where T : class
+    {
+        var stopwatch = Stopwatch.StartNew();
+        do
+        {
+            try
+            {
+                mock.Verify(expression, times);
+                return;
+            }
+            catch (MockException)
+            {
+                if (stopwatch.Elapsed > timeout)
+                {
+                    // when timed out rethrow the exception
+                    throw;
+                }
+                // else keep on repeating
+                await Task.Delay(50);
+            }
+        } while (true);
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Test/Consumer/ConsumerInstanceMessageProcessorTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Consumer/ConsumerInstanceMessageProcessorTest.cs
@@ -13,7 +13,7 @@ public class ConsumerInstanceMessageProcessorTest
     {
         _busMock = new MessageBusMock();
         _messageProviderMock = new Mock<MessageProvider<byte[]>>();
-        _transportMessage = Array.Empty<byte>();
+        _transportMessage = [];
         _topic = "topic";
         var messageBusSettings = new MessageBusSettings();
         _handlerSettings = new HandlerBuilder<SomeRequest, SomeResponse>(messageBusSettings).Topic(_topic).WithHandler<IRequestHandler<SomeRequest, SomeResponse>>().ConsumerSettings;

--- a/src/Tests/SlimMessageBus.Host.Test/GlobalUsings.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/GlobalUsings.cs
@@ -10,5 +10,6 @@ global using Moq;
 
 global using SlimMessageBus.Host.Interceptor;
 global using SlimMessageBus.Host.Serialization;
+global using SlimMessageBus.Host.Serialization.Json;
 
 global using Xunit;

--- a/src/Tests/SlimMessageBus.Host.Test/Hybrid/HybridMessageBusTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Hybrid/HybridMessageBusTest.cs
@@ -38,6 +38,7 @@ public class HybridMessageBusTest
         _serviceProviderMock.Setup(x => x.GetService(typeof(IMessageSerializer))).Returns(_messageSerializerMock.Object);
         _serviceProviderMock.Setup(x => x.GetService(typeof(IMessageTypeResolver))).Returns(new AssemblyQualifiedNameMessageTypeResolver());
         _serviceProviderMock.Setup(x => x.GetService(typeof(ILoggerFactory))).Returns(_loggerFactoryMock.Object);
+        _serviceProviderMock.Setup(x => x.GetService(typeof(IEnumerable<IMessageBusLifecycleInterceptor>))).Returns(Array.Empty<IMessageBusLifecycleInterceptor>());
 
         _loggerFactoryMock.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(_loggerMock.Object);
 
@@ -47,7 +48,7 @@ public class HybridMessageBusTest
             mbb.Produce<AnotherMessage>(x => x.DefaultTopic("topic2"));
             mbb.WithProvider(mbs =>
             {
-                _bus1Mock = new Mock<MessageBusBase>(new[] { mbs });
+                _bus1Mock = new Mock<MessageBusBase>([mbs]);
                 _bus1Mock.SetupGet(x => x.Settings).Returns(mbs);
 
                 _bus1Mock.Setup(x => x.ProducePublish(It.IsAny<SomeMessage>(), It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<IMessageBusTarget>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);

--- a/src/Tests/SlimMessageBus.Host.Test/MessageBusTested.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/MessageBusTested.cs
@@ -37,6 +37,8 @@ public class MessageBusTested : MessageBusBase
 
     protected override async Task<object> ProduceToTransport(object message, string path, byte[] messagePayload, IDictionary<string, object> messageHeaders, IMessageBusTarget targetBus, CancellationToken cancellationToken = default)
     {
+        await EnsureInitFinished();
+
         var messageType = message.GetType();
         OnProduced(messageType, path, message);
 

--- a/src/Tests/SlimMessageBus.Host.Test/SampleMessages.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/SampleMessages.cs
@@ -60,3 +60,17 @@ public interface ICustomConsumer<T>
 
     Task MethodThatHasParamatersThatCannotBeSatisfied(T message, DateTimeOffset dateTimeOffset, CancellationToken cancellationToken);
 }
+
+public class RequestA : IRequest<ResponseA>
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+}
+
+public class ResponseA
+{
+    public string Id { get; set; }
+}
+
+public class RequestB : IRequest<ResponseB> { }
+
+public class ResponseB { }

--- a/src/secrets.txt.sample
+++ b/src/secrets.txt.sample
@@ -13,10 +13,10 @@ kafka_username=user
 kafka_password=password
 
 mqtt_server=localhost
+mqtt_secure=false
 mqtt_port=1883
 mqtt_username=
 mqtt_password=
-mqtt_secure=false
 
 sqlserver_connectionstring=Server=localhost;Initial Catalog=SlimMessageBus_Outbox;User ID=sa;Password=SuperSecretP@55word;TrustServerCertificate=true;MultipleActiveResultSets=true;
 


### PR DESCRIPTION
- Ensure SQL tables are provisioned before the first publish (and without having to start consumers).
- Send Created bus lifecycle event to be able to hook into Master bus creation
- Add baseline performance test for Outbox.


The test (`OutboxBenchmarkTests`) would be run locally against the same machine (GitHub Actions agent). It collects the times it took to produce and then consumes N messages. We can use the times to compare if the new enhancements are better.  In the future more types of use cases could be added to baseline the Outbox from different angles.


For example, a run from my local machine to the Azure Service Bus + Azure SQL instance, for 1000 messages:

With Outbox:
```
[12:59:34 INF] SlimMessageBus.Host.Outbox.DbContext.Test.OutboxBenchmarkTests Message Publish took: "00:00:18.2214666"
[12:59:34 INF] SlimMessageBus.Host.Outbox.DbContext.Test.OutboxBenchmarkTests Message Consume took: "00:01:42.5709066"
```

Without Outbox:
```
[12:57:33 INF] SlimMessageBus.Host.Outbox.DbContext.Test.OutboxBenchmarkTests Message Publish took: "00:00:02.2195892"
[12:57:33 INF] SlimMessageBus.Host.Outbox.DbContext.Test.OutboxBenchmarkTests Message Consume took: "00:00:06.5525862"
```