### PR TITLE
#273 Wrap IOutboxMigrationService resolution in a scope

### DIFF
--- a/src/SlimMessageBus.Host.Outbox/Interceptors/OutboxSendingTask.cs
+++ b/src/SlimMessageBus.Host.Outbox/Interceptors/OutboxSendingTask.cs
@@ -106,14 +106,19 @@ internal class OutboxSendingTask(
 
     private static async Task MigrateSchema(IServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
+        var scope = serviceProvider.CreateScope();
         try
         {
-            var outboxMigrationService = serviceProvider.GetRequiredService<IOutboxMigrationService>();
+            var outboxMigrationService = scope.ServiceProvider.GetRequiredService<IOutboxMigrationService>();
             await outboxMigrationService.Migrate(cancellationToken);
         }
         catch (Exception e)
         {
             throw new MessageBusException("Outbox schema migration failed", e);
+        }
+        finally
+        {
+            await ((IAsyncDisposable)scope).DisposeAsync();
         }
     }
 


### PR DESCRIPTION
`OutboxSendingTask.MigrateSchema` resolves `IOutboxMigrationService` within a scope to satisfy `ISqlOutboxRepository` registration.

```
System.InvalidOperationException: 'Cannot resolve 'SlimMessageBus.Host.Outbox.IOutboxMigrationService' from root provider because it requires scoped service 'SlimMessageBus.Host.Outbox.Sql.ISqlOutboxRepository'.'
```
