### PR TITLE
Switch to adopt JDK distro for SonarCloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         #if: github.event_name == 'pull_request_target'
         uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: "adopt"
           java-version: "17"
 
       - name: SonarCloud - Install SonarCloud scanner


### PR DESCRIPTION
The zulu JDK distro cannot be pulled at the moment. Switching to another distribution.
Similar issue: https://github.com/actions/setup-java/issues/335 