### PR TITLE
[Host.Outbox] Ability to filter UseSqlTransaction and UseOutbox by message type

### DIFF
--- a/docs/plugin_outbox.md
+++ b/docs/plugin_outbox.md
@@ -50,9 +50,9 @@ builder.Services.AddSlimMessageBus(mbb =>
         .AddChildBus("Memory", mbb =>
         {
             mbb.WithProviderMemory()
-                .AutoDeclareFrom(Assembly.GetExecutingAssembly(), consumerTypeFilter: t => t.Name.Contains("Command"))
-                //.UseTransactionScope(); // Consumers/Handlers will be wrapped in a TransactionScope
-                .UseSqlTransaction(); // Consumers/Handlers will be wrapped in a SqlTransaction
+                .AutoDeclareFrom(Assembly.GetExecutingAssembly(), consumerTypeFilter: t => t.Name.EndsWith("CommandHandler"))
+                //.UseTransactionScope(messageTypeFilter: t => t.Name.EndsWith("Command")) // Consumers/Handlers will be wrapped in a TransactionScope
+                .UseSqlTransaction(messageTypeFilter: t => t.Name.EndsWith("Command")); // Consumers/Handlers will be wrapped in a SqlTransaction ending with Command
         })
         .AddChildBus("AzureSB", mbb =>
         {
@@ -78,7 +78,8 @@ builder.Services.AddSlimMessageBus(mbb =>
                     // OR if you want just this producer to sent via outbox
                     // x.UseOutbox();
                 })
-                .UseOutbox(); // All outgoing messages from this bus will go out via an outbox
+                // All outgoing messages from this bus will go out via an outbox
+                .UseOutbox(/* messageTypeFilter: t => t.Name.EndsWith("Command") */); // Additionaly, can apply filter do determine messages that should go out via outbox                
         })
         .AddServicesFromAssembly(Assembly.GetExecutingAssembly())
         .AddJsonSerializer()

--- a/src/Host.Plugin.Properties.xml
+++ b/src/Host.Plugin.Properties.xml
@@ -4,7 +4,7 @@
   <Import Project="Common.NuGet.Properties.xml" />
 
   <PropertyGroup>
-    <Version>2.4.3</Version>
+    <Version>2.5.0-rc1</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/Samples/Sample.OutboxWebApi/Program.cs
+++ b/src/Samples/Sample.OutboxWebApi/Program.cs
@@ -38,9 +38,9 @@ builder.Services.AddSlimMessageBus(mbb =>
         .AddChildBus("Memory", mbb =>
         {
             mbb.WithProviderMemory()
-                .AutoDeclareFrom(Assembly.GetExecutingAssembly(), consumerTypeFilter: t => t.Name.Contains("Command"))
-                //.UseTransactionScope(); // Consumers/Handlers will be wrapped in a TransactionScope
-                .UseSqlTransaction(); // Consumers/Handlers will be wrapped in a SqlTransaction
+                .AutoDeclareFrom(Assembly.GetExecutingAssembly(), consumerTypeFilter: t => t.Name.EndsWith("CommandHandler"))
+                //.UseTransactionScope(messageTypeFilter: t => t.Name.EndsWith("Command")) // Consumers/Handlers will be wrapped in a TransactionScope
+                .UseSqlTransaction(messageTypeFilter: t => t.Name.EndsWith("Command")); // Consumers/Handlers will be wrapped in a SqlTransaction ending with Command
         })
         .AddChildBus("AzureSB", mbb =>
         {
@@ -66,7 +66,8 @@ builder.Services.AddSlimMessageBus(mbb =>
                     // OR if you want just this producer to sent via outbox
                     // x.UseOutbox();
                 })
-                .UseOutbox(); // All outgoing messages from this bus will go out via an outbox
+                // All outgoing messages from this bus will go out via an outbox
+                .UseOutbox(/* messageTypeFilter: t => t.Name.EndsWith("Command") */); // Additionaly, can apply filter do determine messages that should go out via outbox                
         })
         .AddServicesFromAssembly(Assembly.GetExecutingAssembly())
         .AddJsonSerializer()

--- a/src/SlimMessageBus.Host.Memory/MemoryMessageBusBuilder.cs
+++ b/src/SlimMessageBus.Host.Memory/MemoryMessageBusBuilder.cs
@@ -172,5 +172,5 @@ public class MemoryMessageBusBuilder : MessageBusBuilder
     /// <param name="consumerTypeFilter">Allows to apply a filter for any found consumer/handler.</param>
     /// <param name="messageTypeToTopicConverter">By default the type name is used for the topic name. This can be used to customize the topic name. For example, if have types that have same names but are in the namespaces, you might want to include the full type in the topic name.</param>
     public MemoryMessageBusBuilder AutoDeclareFrom(Assembly assembly, Func<Type, bool> consumerTypeFilter = null, Func<Type, string> messageTypeToTopicConverter = null)
-        => AutoDeclareFrom(new[] { assembly }, consumerTypeFilter, messageTypeToTopicConverter);
+        => AutoDeclareFrom([assembly], consumerTypeFilter, messageTypeToTopicConverter);
 }

--- a/src/SlimMessageBus.Host.Outbox.Sql/Configuration/BuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Outbox.Sql/Configuration/BuilderExtensions.cs
@@ -5,16 +5,18 @@ using SlimMessageBus.Host;
 public static class BuilderExtensions
 {
     static readonly internal string PropertySqlTransactionEnabled = "SqlTransaction_Enabled";
-   
+    static readonly internal string PropertySqlTransactionFilter = "SqlTransaction_Filter";
+
     /// <summary>
     /// Enables the creation of <see cref="SqlTransaction"/> for every message consumed by this bus.
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="enabled"></param>
+    /// <param name="messageTypeFilter">When enabled, allows to decide if the transaction should be created.</param>
     /// <returns></returns>
-    public static MessageBusBuilder UseSqlTransaction(this MessageBusBuilder builder, bool enabled = true)
+    public static MessageBusBuilder UseSqlTransaction(this MessageBusBuilder builder, bool enabled = true, Func<Type, bool> messageTypeFilter = null)
     {
-        builder.Settings.Properties[PropertySqlTransactionEnabled] = enabled;
+        SetTransactionScopeProps(builder.Settings, enabled, messageTypeFilter);
         return builder;
     }
 
@@ -23,10 +25,11 @@ public static class BuilderExtensions
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="enabled"></param>
+    /// <param name="messageTypeFilter">When enabled, allows to decide if the transaction should be created.</param>
     /// <returns></returns>
-    public static ConsumerBuilder<T> UseSqlTransaction<T>(this ConsumerBuilder<T> builder, bool enabled = true)
+    public static ConsumerBuilder<T> UseSqlTransaction<T>(this ConsumerBuilder<T> builder, bool enabled = true, Func<Type, bool> messageTypeFilter = null)
     {
-        builder.Settings.Properties[PropertySqlTransactionEnabled] = enabled;
+        SetTransactionScopeProps(builder.Settings, enabled, messageTypeFilter);
         return builder;
     }
 
@@ -35,10 +38,17 @@ public static class BuilderExtensions
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="enabled"></param>
+    /// <param name="messageTypeFilter">When enabled, allows to decide if the transaction should be created.</param>
     /// <returns></returns>
-    public static HandlerBuilder<T, R> UseSqlTransaction<T, R>(this HandlerBuilder<T, R> builder, bool enabled = true)
+    public static HandlerBuilder<T, R> UseSqlTransaction<T, R>(this HandlerBuilder<T, R> builder, bool enabled = true, Func<Type, bool> messageTypeFilter = null)
     {
-        builder.Settings.Properties[PropertySqlTransactionEnabled] = enabled;
+        SetTransactionScopeProps(builder.Settings, enabled, messageTypeFilter);
         return builder;
+    }
+
+    private static void SetTransactionScopeProps(HasProviderExtensions hasProviderExtensions, bool enabled, Func<Type, bool> messageTypeFilter = null)
+    {
+        hasProviderExtensions.Properties[PropertySqlTransactionEnabled] = enabled;
+        hasProviderExtensions.Properties[PropertySqlTransactionFilter] = messageTypeFilter;
     }
 }

--- a/src/SlimMessageBus.Host.Outbox.Sql/GlobalUsings.cs
+++ b/src/SlimMessageBus.Host.Outbox.Sql/GlobalUsings.cs
@@ -8,5 +8,3 @@ global using Microsoft.Extensions.Logging;
 
 global using SlimMessageBus.Host.Interceptor;
 global using SlimMessageBus.Host.Sql.Common;
-
-

--- a/src/SlimMessageBus.Host.Outbox.Sql/Interceptors/SqlTransactionConsumerInterceptor.cs
+++ b/src/SlimMessageBus.Host.Outbox.Sql/Interceptors/SqlTransactionConsumerInterceptor.cs
@@ -1,66 +1,38 @@
 ﻿namespace SlimMessageBus.Host.Outbox.Sql;
 
-using Microsoft.Extensions.Logging;
-
-using SlimMessageBus;
-using SlimMessageBus.Host.Interceptor;
-
 public abstract class SqlTransactionConsumerInterceptor
 {
 }
 
 /// <summary>
-/// Wraps the consumer in an <see cref="TransactionScope"/> (conditionally).
+/// Wraps the consumer in an <see cref="SqlTransaction"/> (conditionally).
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class SqlTransactionConsumerInterceptor<T>(
-    ILogger<SqlTransactionConsumerInterceptor> logger,
-    ISqlTransactionService transactionService)
+public class SqlTransactionConsumerInterceptor<T>(ILogger<SqlTransactionConsumerInterceptor> logger, ISqlTransactionService transactionService)
     : SqlTransactionConsumerInterceptor, IConsumerInterceptor<T> where T : class
 {
     public async Task<object> OnHandle(T message, Func<Task<object>> next, IConsumerContext context)
     {
-        var sqlTransactionEnabled = IsSqlTransactionEnabled(context);
-        if (sqlTransactionEnabled)
+        logger.LogTrace("SqlTransaction - creating...");
+        await transactionService.BeginTransaction();
+        try
         {
-            logger.LogTrace("SqlTransaction - creating...");
-            await transactionService.BeginTransaction();
-            try
-            {
-                logger.LogDebug("SqlTransaction - created");
+            logger.LogDebug("SqlTransaction - created");
 
-                var result = await next();
+            var result = await next();
 
-                logger.LogTrace("SqlTransaction - committing...");
-                await transactionService.CommitTransaction();
-                logger.LogDebug("SqlTransaction - committed");
-                return result;
-            }
-            catch
-            {
-                logger.LogTrace("SqlTransaction - rolling back...");
-                await transactionService.RollbackTransaction();
-                logger.LogDebug("SqlTransaction - rolled back");
-
-                throw;
-            }
+            logger.LogTrace("SqlTransaction - committing...");
+            await transactionService.CommitTransaction();
+            logger.LogDebug("SqlTransaction - committed");
+            return result;
         }
-
-        return await next();
-    }
-
-    private static bool IsSqlTransactionEnabled(IConsumerContext context)
-    {
-        var bus = context.GetMasterMessageBus();
-        if (bus == null || context is not ConsumerContext consumerContext)
+        catch
         {
-            return false;
+            logger.LogTrace("SqlTransaction - rolling back...");
+            await transactionService.RollbackTransaction();
+            logger.LogDebug("SqlTransaction - rolled back");
+
+            throw;
         }
-
-        // If consumer has outbox enabled, if not set check if bus has outbox enabled
-        var transactionEnabled = consumerContext.ConsumerInvoker.ParentSettings.GetOrDefault<bool?>(BuilderExtensions.PropertySqlTransactionEnabled, null)
-            ?? bus.Settings.GetOrDefault(BuilderExtensions.PropertySqlTransactionEnabled, false);
-
-        return transactionEnabled;
     }
 }

--- a/src/SlimMessageBus.Host.Outbox/Configuration/BuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Outbox/Configuration/BuilderExtensions.cs
@@ -5,17 +5,21 @@ using SlimMessageBus.Host;
 public static class BuilderExtensions
 {
     static readonly internal string PropertyOutboxEnabled = "Outbox_Enabled";
+    static readonly internal string PropertyOutboxFilter = "Outbox_Filter";
     static readonly internal string PropertyTransactionScopeEnabled = "TransactionScope_Enabled";
+    static readonly internal string PropertyTransactionScopeFilter = "TransactionScope_Filter";
 
     /// <summary>
     /// Enables the ProducePublish for all message types in this bus to go via the outbox.
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="enabled"></param>
+    /// <param name="messageTypeFilter">When enabled, allows to decide if the outbox should be used for the given message type.</param>
     /// <returns></returns>
-    public static MessageBusBuilder UseOutbox(this MessageBusBuilder builder, bool enabled = true)
+    public static MessageBusBuilder UseOutbox(this MessageBusBuilder builder, bool enabled = true, Func<Type, bool> messageTypeFilter = null)
     {
         builder.Settings.Properties[PropertyOutboxEnabled] = enabled;
+        builder.Settings.Properties[PropertyOutboxFilter] = messageTypeFilter;
         return builder;
     }
 
@@ -24,10 +28,12 @@ public static class BuilderExtensions
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="enabled"></param>
+    /// <param name="messageTypeFilter">When enabled, allows to decide if the outbox should be used for the given message type.</param>
     /// <returns></returns>
-    public static ProducerBuilder<T> UseOutbox<T>(this ProducerBuilder<T> builder, bool enabled = true)
+    public static ProducerBuilder<T> UseOutbox<T>(this ProducerBuilder<T> builder, bool enabled = true, Func<Type, bool> messageTypeFilter = null)
     {
         builder.Settings.Properties[PropertyOutboxEnabled] = enabled;
+        builder.Settings.Properties[PropertyOutboxFilter] = messageTypeFilter;
         return builder;
     }
 
@@ -36,10 +42,11 @@ public static class BuilderExtensions
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="enabled"></param>
+    /// <param name="messageTypeFilter">When enabled, allows to decide if the transaction should be created.</param>
     /// <returns></returns>
-    public static MessageBusBuilder UseTransactionScope(this MessageBusBuilder builder, bool enabled = true)
+    public static MessageBusBuilder UseTransactionScope(this MessageBusBuilder builder, bool enabled = true, Func<Type, bool> messageTypeFilter = null)
     {
-        builder.Settings.Properties[PropertyTransactionScopeEnabled] = enabled;
+        SetTransactionScopeProps(builder.Settings, enabled, messageTypeFilter);
         return builder;
     }
 
@@ -48,22 +55,30 @@ public static class BuilderExtensions
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="enabled"></param>
+    /// <param name="messageTypeFilter">When enabled, allows to decide if the transaction should be created.</param>
     /// <returns></returns>
-    public static ConsumerBuilder<T> UseTransactionScope<T>(this ConsumerBuilder<T> builder, bool enabled = true)
+    public static ConsumerBuilder<T> UseTransactionScope<T>(this ConsumerBuilder<T> builder, bool enabled = true, Func<Type, bool> messageTypeFilter = null)
     {
-        builder.Settings.Properties[PropertyTransactionScopeEnabled] = enabled;
+        SetTransactionScopeProps(builder.Settings, enabled, messageTypeFilter);
         return builder;
     }
 
     /// <summary>
-    /// Enables the creation of <see cref="TransactionScope"/> every messages on this handler.
+    /// Enables the creation of <see cref="TransactionScope"/> for every messages on this handler.
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="enabled"></param>
+    /// <param name="messageTypeFilter">When enabled, allows to decide if the transaction should be created.</param>
     /// <returns></returns>
-    public static HandlerBuilder<T, R> UseTransactionScope<T, R>(this HandlerBuilder<T, R> builder, bool enabled = true)
+    public static HandlerBuilder<T, R> UseTransactionScope<T, R>(this HandlerBuilder<T, R> builder, bool enabled = true, Func<Type, bool> messageTypeFilter = null)
     {
-        builder.Settings.Properties[PropertyTransactionScopeEnabled] = enabled;
+        SetTransactionScopeProps(builder.Settings, enabled, messageTypeFilter);
         return builder;
+    }
+
+    private static void SetTransactionScopeProps(HasProviderExtensions hasProviderExtensions, bool enabled, Func<Type, bool> messageTypeFilter = null)
+    {
+        hasProviderExtensions.Properties[PropertyTransactionScopeEnabled] = enabled;
+        hasProviderExtensions.Properties[PropertyTransactionScopeFilter] = messageTypeFilter;
     }
 }

--- a/src/SlimMessageBus.Host.Outbox/Configuration/SettingsExtensions.cs
+++ b/src/SlimMessageBus.Host.Outbox/Configuration/SettingsExtensions.cs
@@ -1,12 +1,21 @@
 ﻿namespace SlimMessageBus.Host.Outbox;
 
-using SlimMessageBus.Host;
-
 public static class SettingsExtensions
 {
-    public static bool IsOutboxEnabled(this ProducerSettings producerSettings, MessageBusSettings messageBusSettings) =>
-        producerSettings.GetOrDefault<bool>(BuilderExtensions.PropertyOutboxEnabled, messageBusSettings);
+    public static bool IsEnabledForMessageType(this HasProviderExtensions hasProviderExtensions, MessageBusSettings messageBusSettings, string propertyEnabled, string propertyMessageTypeFilter, Type messageType)
+    {
+        var enabled = hasProviderExtensions.GetOrDefault(propertyEnabled, messageBusSettings, false);
+        if (!enabled)
+        {
+            return false;
+        }
 
-    public static bool IsTransactionScopeEnabled(this ConsumerSettings consumerSettings, MessageBusSettings messageBusSettings) =>
-        consumerSettings.GetOrDefault<bool>(BuilderExtensions.PropertyTransactionScopeEnabled, messageBusSettings);
+        var messageTypeFilter = hasProviderExtensions.GetOrDefault<Func<Type, bool>>(propertyMessageTypeFilter, messageBusSettings, null);
+        if (messageTypeFilter != null)
+        {
+            return messageTypeFilter(messageType);
+        }
+
+        return true;
+    }
 }

--- a/src/SlimMessageBus.Host.Outbox/Interceptors/TransactionScopeConsumerInterceptor.cs
+++ b/src/SlimMessageBus.Host.Outbox/Interceptors/TransactionScopeConsumerInterceptor.cs
@@ -10,25 +10,24 @@ public abstract class TransactionScopeConsumerInterceptor
 /// Wraps the consumer in an <see cref="TransactionScope"/> (conditionally).
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class TransactionScopeConsumerInterceptor<T>(
-    ILogger<TransactionScopeConsumerInterceptor> logger,
-    OutboxSettings settings)
+public class TransactionScopeConsumerInterceptor<T>(ILogger<TransactionScopeConsumerInterceptor> logger, OutboxSettings settings)
     : TransactionScopeConsumerInterceptor, IConsumerInterceptor<T> where T : class
 {
-    private readonly ILogger _logger = logger;
-    private readonly OutboxSettings _settings = settings;
-
     public async Task<object> OnHandle(T message, Func<Task<object>> next, IConsumerContext context)
     {
-        _logger.LogTrace("TransactionScope - creating...");
-        using var tx = new TransactionScope(scopeOption: TransactionScopeOption.Required, asyncFlowOption: TransactionScopeAsyncFlowOption.Enabled, transactionOptions: new TransactionOptions { IsolationLevel = _settings.TransactionScopeIsolationLevel });
-        _logger.LogDebug("TransactionScope - created");
+        logger.LogTrace("TransactionScope - creating...");
+        using var tx = new TransactionScope(
+            scopeOption: TransactionScopeOption.Required,
+            asyncFlowOption: TransactionScopeAsyncFlowOption.Enabled,
+            transactionOptions: new TransactionOptions { IsolationLevel = settings.TransactionScopeIsolationLevel });
+
+        logger.LogDebug("TransactionScope - created");
 
         var result = await next();
 
-        _logger.LogTrace("TransactionScope - completing...");
+        logger.LogTrace("TransactionScope - completing...");
         tx.Complete();
-        _logger.LogDebug("TransactionScope - completed");
+        logger.LogDebug("TransactionScope - completed");
 
         return result;
     }


### PR DESCRIPTION
What:
Adding an option to determine message types filter in the following outbox declarations:

```cs
mbb.UseOutbox(messageTypeFilter: t => t.Name.EndsWith("Command"));
mbb.UseSqlTransaction(messageTypeFilter: t => t.Name.EndsWith("Command"));
mbb.UseTransactionScope(messageTypeFilter: t => t.Name.EndsWith("Command"));
```

The filtering happens at configuration time.

Why:
We can have an In-Memory bus for CQRS where only command messages require to be wrapped in a transaction and query messages do not. Without it we would have to declare two memory child buses - for commands and queries.

Optimization:
Moreover, the `UseSqlTransaction()` will be registered for the enabled message types (consumers, or bus) only. 
Before the interceptor was registered DI wide, and interceptor was checking matching consumers at runtime.