### PR TITLE
[Host.Kafka] Fix and improve commit logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
         working-directory: ./src
 
       - name: Install Coverlet
+        #if: false
         run: find . -name "*.Test.csproj" | xargs -t -I {} dotnet add {} package coverlet.collector
         working-directory: ./src
 
@@ -119,10 +120,10 @@ jobs:
           azure_eventhub_connectionstring: ${{ secrets.azure_eventhub_connectionstring }}
           azure_storagecontainer_connectionstring: ${{ secrets.azure_storagecontainer_connectionstring }}
 
-          kafka_brokers: ${{ secrets.kafka_brokers }}
-          kafka_username: ${{ secrets.kafka_username }}
-          kafka_password: ${{ secrets.kafka_password }}
-          kafka_secure: ${{ secrets.kafka_secure }}
+          #kafka_brokers: ${{ secrets.kafka_brokers }}
+          #kafka_username: ${{ secrets.kafka_username }}
+          #kafka_password: ${{ secrets.kafka_password }}
+          #kafka_secure: ${{ secrets.kafka_secure }}
 
           _mqtt_server: ${{ secrets.mqtt_server }}
           _mqtt_port: ${{ secrets.mqtt_port }}
@@ -137,10 +138,10 @@ jobs:
           sqlserver_connectionstring: ${{ secrets.sqlserver_connectionstring }}
 
           # Connects to the local Test Containers
-          _kafka_brokers: localhost:9092
-          _kafka_username: user
-          _kafka_password: password
-          _kafka_secure: false
+          kafka_brokers: localhost:9092
+          kafka_username: user
+          kafka_password: password
+          kafka_secure: false
 
           mqtt_server: localhost
           mqtt_port: 1883
@@ -192,6 +193,7 @@ jobs:
           name: .NET Tests
           path: ./test-results/*.trx
           reporter: dotnet-trx
+          fail-on-error: false
 
       - name: Copy NuGet packages
         shell: bash

--- a/docs/provider_kafka.t.md
+++ b/docs/provider_kafka.t.md
@@ -14,6 +14,7 @@ Please read the [Introduction](intro.md) before reading this provider documentat
 - [Consumers](#consumers)
   - [Offset Commit](#offset-commit)
   - [Consumer Error Handling](#consumer-error-handling)
+  - [Debugging](#debugging)
 - [Deployment](#deployment)
 
 ## Underlying client
@@ -22,13 +23,13 @@ The SMB Kafka implementation uses [confluent-kafka-dotnet](https://github.com/co
 
 When troubleshooting or fine tuning it is worth reading the `librdkafka` and `confluent-kafka-dotnet` docs:
 
-- [Introduction](https://github.com/edenhill/librdkafka/blob/master/INTRODUCTION.md
-- [Broker version compatibility](https://github.com/edenhill/librdkafka/wiki/Broker-version-compatibility)
-- [Using SSL with librdkafka](https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka)
+- [Introduction](https://github.com/confluentinc/librdkafka/blob/master/INTRODUCTION.md)
+- [Broker version compatibility](https://github.com/confluentinc/librdkafka/blob/master/INTRODUCTION.md#broker-version-compatibility)
+- [Using SSL with librdkafka](https://github.com/confluentinc/librdkafka/wiki/Using-SSL-with-librdkafka)
 
 ## Configuration properties
 
-Producer, consumer and global configuration properties are described [here](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).
+Producer, consumer and global configuration properties are described [here](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md).
 The configuration on the underlying Kafka client can be adjusted like so:
 
 ```cs
@@ -52,7 +53,7 @@ services.AddSlimMessageBus(mbb =>
 
 ### Minimizing message latency
 
-There is a good description [here](https://github.com/edenhill/librdkafka/wiki/How-to-decrease-message-latency) on improving the latency by applying producer/consumer settings on librdkafka. Here is how you enter the settings using SlimMessageBus:
+There is a good description [here](https://github.com/confluentinc/librdkafka/wiki/How-to-decrease-message-latency) on improving the latency by applying producer/consumer settings on librdkafka. Here is how you enter the settings using SlimMessageBus:
 
 ```cs
 services.AddSlimMessageBus(mbb =>
@@ -210,7 +211,8 @@ mbb
 
 ### Offset Commit
 
-In the current Kafka provider implementation, SMB handles the manual commit of topic-partition offsets for the consumer. This configuration is controlled through the following methods on the consumer builder:
+In the current Kafka provider implementation, SMB handles the manual commit of topic-partition offsets for the consumer.Th
+is configuration is controlled through the following methods on the consumer builder:
 
 - `CheckpointEvery(int)` – Commits the offset after a specified number of processed messages.
 - `CheckpointAfter(TimeSpan)` – Commits the offset after a specified time interval.
@@ -235,6 +237,35 @@ The error handler can perform the following actions:
 - Stop the consumer's message processing (currently not supported), though the circuit breaker feature from [this pull request](https://github.com/zarusz/SlimMessageBus/pull/282) could be used as an alternative.
 
 If no custom error handler is provided, the provider logs the exception and moves on to process the next message.
+
+### Debugging
+
+Kafka uses a sophisticated protocol for partition assignment:
+
+- Partition assignments may change due to factors like rebalancing.
+- A running consumer instance might not receive any partitions if there are more consumers than partitions for a given topic.
+
+To better understand what's happening, you can enable Debug level logging in your library, such as SlimMessageBus.Host.Kafka.KafkaGroupConsumer.
+
+At this logging level, you can track the lifecycle events of the consumer group:
+
+```
+[00:03:06 INF] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Subscribing to topics: 4p5ma6io-test-ping
+[00:03:06 INF] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Consumer loop started
+[00:03:12 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Assigned partition, Topic: 4p5ma6io-test-ping, Partition: [0]
+[00:03:12 INF] SlimMessageBus.Host.Kafka.KafkaPartitionConsumer Creating consumer for Group: subscriber, Topic: 4p5ma6io-test-ping, Partition: [0]
+[00:03:12 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Assigned partition, Topic: 4p5ma6io-test-ping, Partition: [1]
+[00:03:12 INF] SlimMessageBus.Host.Kafka.KafkaPartitionConsumer Creating consumer for Group: subscriber, Topic: 4p5ma6io-test-ping, Partition: [1]
+...
+[00:03:15 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Received message with Topic: 4p5ma6io-test-ping, Partition: [1], Offset: 98578, payload size: 57
+[00:03:15 INF] SlimMessageBus.Host.Kafka.Test.KafkaMessageBusIt.PingConsumer Got message 073 on topic 4p5ma6io-test-ping.
+[00:03:15 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Received message with Topic: 4p5ma6io-test-ping, Partition: [1], Offset: 98579, payload size: 57
+[00:03:15 INF] SlimMessageBus.Host.Kafka.Test.KafkaMessageBusIt.PingConsumer Got message 075 on topic 4p5ma6io-test-ping.
+[00:03:16 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Reached end of partition, Topic: 4p5ma6io-test-ping, Partition: [0], Offset: 100403
+[00:03:16 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Commit Offset, Topic: 4p5ma6io-test-ping, Partition: [0], Offset: 100402
+[00:03:16 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Reached end of partition, Topic: 4p5ma6io-test-ping, Partition: [1], Offset: 98580
+[00:03:16 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Commit Offset, Topic: 4p5ma6io-test-ping, Partition: [1], Offset: 98579
+```
 
 ## Deployment
 

--- a/src/Host.Plugin.Properties.xml
+++ b/src/Host.Plugin.Properties.xml
@@ -4,7 +4,7 @@
   <Import Project="Common.NuGet.Properties.xml" />
 
   <PropertyGroup>
-    <Version>2.5.3-rc1</Version>
+    <Version>2.5.3-rc2</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/Infrastructure/docker-compose.yml
+++ b/src/Infrastructure/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: "3.4"
 
 services:
   zookeeper:
@@ -16,13 +16,13 @@ services:
       - "9092:9092"
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_CREATE_TOPICS: "user-test-ping:2:1,user-test-echo:2:1"
+      KAFKA_CREATE_TOPICS: "user-test-ping:2:1,user-test-echo:2:1,user-test-echo-resp:2:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     depends_on:
       - zookeeper
     networks:
       - slim
-      
+
   mqtt:
     container_name: slim.mqtt
     image: eclipse-mosquitto:2.0.18
@@ -74,7 +74,7 @@ services:
       - "11002:11002"
     networks:
       - slim
-  
+
   nats:
     container_name: slim.nats
     image: nats:2.10
@@ -82,8 +82,6 @@ services:
       - 4222:4222
     networks:
       - slim
-    
 
 networks:
   slim: {}
- 

--- a/src/SlimMessageBus.Host.Kafka/Consumer/IKafkaPartitionConsumer.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/IKafkaPartitionConsumer.cs
@@ -11,7 +11,7 @@ public interface IKafkaPartitionConsumer : IDisposable
 
     void OnPartitionAssigned(TopicPartition partition);
     Task OnMessage(ConsumeResult message);
-    void OnPartitionEndReached(TopicPartitionOffset offset);
+    void OnPartitionEndReached();
     void OnPartitionRevoked();
 
     void OnClose();

--- a/src/SlimMessageBus.Host.Kafka/SlimMessageBus.Host.Kafka.csproj
+++ b/src/SlimMessageBus.Host.Kafka/SlimMessageBus.Host.Kafka.csproj
@@ -10,12 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\SlimMessageBus.Host\SlimMessageBus.Host.csproj" />
     <ProjectReference Include="..\SlimMessageBus\SlimMessageBus.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="SlimMessageBus.Host.Kafka.Test" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaGroupConsumerTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaGroupConsumerTests.cs
@@ -1,0 +1,46 @@
+﻿namespace SlimMessageBus.Host.Kafka.Test;
+
+public class KafkaGroupConsumerTests
+{
+    private readonly Mock<ILogger<KafkaGroupConsumer>> _loggerMock = new();
+    private readonly KafkaGroupConsumer _subject;
+
+    public KafkaGroupConsumerTests()
+    {
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(_loggerMock.Object);
+
+        var processorFactoryMock = new Mock<Func<TopicPartition, IKafkaCommitController, IKafkaPartitionConsumer>>();
+
+        var providerSettings = new KafkaMessageBusSettings("host");
+
+        var subjectMock = new Mock<KafkaGroupConsumer>(loggerFactoryMock.Object, providerSettings, "group", new List<string> { "topic" }, processorFactoryMock.Object) { CallBase = true };
+        _subject = subjectMock.Object;
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void When_OnOffsetsCommitted_Given_Succeeded_Then_ShouldLog(bool debugEnabled)
+    {
+        // arrangen
+        _loggerMock.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(debugEnabled);
+
+        var tpo = new TopicPartitionOffset("topic", 0, 10);
+        var committedOffset = new CommittedOffsets([new TopicPartitionOffsetError(tpo, null)], new Error(ErrorCode.NoError));
+
+        // act
+        _subject.OnOffsetsCommitted(committedOffset);
+
+        // assert
+
+        _loggerMock.Verify(x => x.Log(LogLevel.Information, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Once);
+        _loggerMock.Verify(x => x.IsEnabled(LogLevel.Debug), Times.Once);
+        if (debugEnabled)
+        {
+            _loggerMock.Verify(x => x.Log(LogLevel.Debug, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Once);
+        }
+        _loggerMock.VerifyNoOtherCalls();
+    }
+
+}

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaPartitionConsumerForConsumersTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaPartitionConsumerForConsumersTest.cs
@@ -1,12 +1,6 @@
 ﻿namespace SlimMessageBus.Host.Kafka.Test;
 
-using Confluent.Kafka;
-
-using Microsoft.Extensions.Logging.Abstractions;
-
-using SlimMessageBus.Host;
-
-using ConsumeResult = Confluent.Kafka.ConsumeResult<Confluent.Kafka.Ignore, byte[]>;
+using ConsumeResult = ConsumeResult<Ignore, byte[]>;
 
 public class KafkaPartitionConsumerForConsumersTest : IDisposable
 {
@@ -41,7 +35,7 @@ public class KafkaPartitionConsumerForConsumersTest : IDisposable
 
         var headerSerializer = new StringValueSerializer();
 
-        _subject = new Lazy<KafkaPartitionConsumerForConsumers>(() => new KafkaPartitionConsumerForConsumers(massageBusMock.Bus.LoggerFactory, new[] { _consumerBuilder.ConsumerSettings }, group, _topicPartition, _commitControllerMock.Object, headerSerializer, massageBusMock.Bus));
+        _subject = new Lazy<KafkaPartitionConsumerForConsumers>(() => new KafkaPartitionConsumerForConsumers(massageBusMock.Bus.LoggerFactory, [_consumerBuilder.ConsumerSettings], group, _topicPartition, _commitControllerMock.Object, headerSerializer, massageBusMock.Bus));
     }
 
     public void Dispose()
@@ -64,7 +58,7 @@ public class KafkaPartitionConsumerForConsumersTest : IDisposable
         await _subject.Value.OnMessage(message);
 
         // act
-        _subject.Value.OnPartitionEndReached(message.TopicPartitionOffset);
+        _subject.Value.OnPartitionEndReached();
 
         // assert
         _commitControllerMock.Verify(x => x.Commit(message.TopicPartitionOffset), Times.Once);
@@ -114,7 +108,7 @@ public class KafkaPartitionConsumerForConsumersTest : IDisposable
             Topic = _topicPartition.Topic,
             Partition = _topicPartition.Partition,
             Offset = 10 + offsetAdd,
-            Message = new Message<Ignore, byte[]> { Key = null, Value = new byte[] { 10, 20 } },
+            Message = new Message<Ignore, byte[]> { Key = null, Value = [10, 20] },
             IsPartitionEOF = false,
         };
     }

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaPartitionConsumerForResponsesTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaPartitionConsumerForResponsesTest.cs
@@ -2,9 +2,7 @@
 
 using System.Text;
 
-using Confluent.Kafka;
-
-using ConsumeResult = Confluent.Kafka.ConsumeResult<Confluent.Kafka.Ignore, byte[]>;
+using ConsumeResult = ConsumeResult<Ignore, byte[]>;
 
 public class KafkaPartitionConsumerForResponsesTest : IDisposable
 {
@@ -45,13 +43,17 @@ public class KafkaPartitionConsumerForResponsesTest : IDisposable
     }
 
     [Fact]
-    public void When_OnPartitionEndReached_Then_ShouldCommit()
+    public async Task When_OnPartitionEndReached_Then_ShouldCommit()
     {
         // arrange
         var partition = new TopicPartitionOffset(_topicPartition, new Offset(10));
+        var message = GetSomeMessage();
+
+        _subject.OnPartitionAssigned(_topicPartition);
+        await _subject.OnMessage(message);
 
         // act
-        _subject.OnPartitionEndReached(partition);
+        _subject.OnPartitionEndReached();
 
         // assert
         _commitControllerMock.Verify(x => x.Commit(partition), Times.Once);
@@ -125,7 +127,7 @@ public class KafkaPartitionConsumerForResponsesTest : IDisposable
             Message = new Message<Ignore, byte[]>
             {
                 Key = null,
-                Value = new byte[] { 10, 20 },
+                Value = [10, 20],
                 Headers = new Headers
                 {
                     { "test-header", Encoding.UTF8.GetBytes("test-value") }
@@ -145,3 +147,4 @@ public class KafkaPartitionConsumerForResponsesTest : IDisposable
 
     #endregion
 }
+

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/GlobalUsings.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/GlobalUsings.cs
@@ -3,12 +3,12 @@
 global using FluentAssertions;
 
 global using Microsoft.Extensions.Logging;
+global using Microsoft.Extensions.Logging.Abstractions;
 
 global using Moq;
 
 global using SecretStore;
 
-global using SlimMessageBus.Host;
 global using SlimMessageBus.Host.Serialization;
 
 global using Xunit;

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/appsettings.json
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/appsettings.json
@@ -5,6 +5,8 @@
       "Override": {
         "SlimMessageBus": "Information",
         "SlimMessageBus.Host.Kafka.KafkaGroupConsumer": "Debug",
+        "SlimMessageBus.Host.Kafka.KafkaPartitionConsumer": "Verbose",
+        "SlimMessageBus.Host.Kafka.KafkaMessageBus": "Debug",
         "Microsoft": "Warning"
       }
     }


### PR DESCRIPTION
There was an issue raised in [#131](https://github.com/zarusz/SlimMessageBus/issues/131#issuecomment-2344638738). Doing further investigation I have found:

- With `EnablePartitionEof` set to `true`, when the partition ended, SMB was committing too advanced a partition index.
- The SMB-driven manual commit with the `CheckpointAfter(TimeSpan)` might not happen after the desired time when there are no protocol events that happen (partition assignment or partition EOF).

Moreover, the Confluent.Kafka library has being upgraded from 2.3.0 to 2.5.2.