### PR TITLE
[Host.AzureServiceBus] Pass ServiceProvider as arg to client factory

### DIFF
--- a/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusMessageBus.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusMessageBus.cs
@@ -62,7 +62,7 @@ public class ServiceBusMessageBus : MessageBusBase<ServiceBusMessageBusSettings>
             AddInit(ProvisionTopology());
         }
 
-        _client = ProviderSettings.ClientFactory();
+        _client = ProviderSettings.ClientFactory(Settings.ServiceProvider, ProviderSettings);
 
         _producerByPath = new SafeDictionaryWrapper<string, ServiceBusSender>(path =>
         {

--- a/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusMessageBusSettings.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusMessageBusSettings.cs
@@ -6,8 +6,8 @@ using Azure.Messaging.ServiceBus.Administration;
 public class ServiceBusMessageBusSettings : HasProviderExtensions
 {
     public string ConnectionString { get; set; }
-    public Func<ServiceBusClient> ClientFactory { get; set; }
-    public Func<ServiceBusAdministrationClient> AdminClientFactory { get; set; }
+    public Func<IServiceProvider, ServiceBusMessageBusSettings, ServiceBusClient> ClientFactory { get; set; }
+    public Func<IServiceProvider, ServiceBusMessageBusSettings, ServiceBusAdministrationClient> AdminClientFactory { get; set; }
     public Func<string, ServiceBusClient, ServiceBusSender> SenderFactory { get; set; }
     public Func<TopicSubscriptionParams, ServiceBusProcessorOptions> ProcessorOptionsFactory { get; set; }
     public Func<TopicSubscriptionParams, ServiceBusProcessorOptions, ServiceBusClient, ServiceBusProcessor> ProcessorFactory { get; set; }
@@ -45,8 +45,8 @@ public class ServiceBusMessageBusSettings : HasProviderExtensions
 
     public ServiceBusMessageBusSettings()
     {
-        ClientFactory = () => new ServiceBusClient(ConnectionString);
-        AdminClientFactory = () => new ServiceBusAdministrationClient(ConnectionString);
+        ClientFactory = (_, settings) => new ServiceBusClient(settings.ConnectionString);
+        AdminClientFactory = (_, settings) => new ServiceBusAdministrationClient(settings.ConnectionString);
 
         SenderFactory = (path, client) => client.CreateSender(path);
 

--- a/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusTopologyService.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusTopologyService.cs
@@ -15,7 +15,7 @@ public class ServiceBusTopologyService
         _logger = logger;
         _settings = settings;
         _providerSettings = providerSettings;
-        _adminClient = providerSettings.AdminClientFactory();
+        _adminClient = providerSettings.AdminClientFactory(settings.ServiceProvider, providerSettings);
     }
 
     [Flags]

--- a/src/Tests/SlimMessageBus.Host.AzureServiceBus.Test/ServiceBusMessageBusTests.cs
+++ b/src/Tests/SlimMessageBus.Host.AzureServiceBus.Test/ServiceBusMessageBusTests.cs
@@ -29,7 +29,7 @@ public class ServiceBusMessageBusTests : IDisposable
 
         ProviderBusSettings = new ServiceBusMessageBusSettings("connection-string")
         {
-            ClientFactory = () =>
+            ClientFactory = (_, _) =>
             {
                 var client = new Mock<ServiceBusClient>();
                 return client.Object;

--- a/src/Tests/SlimMessageBus.Host.AzureServiceBus.Test/ServiceBusTopologyServiceTests.cs
+++ b/src/Tests/SlimMessageBus.Host.AzureServiceBus.Test/ServiceBusTopologyServiceTests.cs
@@ -30,7 +30,7 @@
 
                 ProviderBusSettings = new ServiceBusMessageBusSettings("connection-string")
                 {
-                    AdminClientFactory = () => _mockAdminClient.Object,
+                    AdminClientFactory = (_, _) => _mockAdminClient.Object,
                     TopologyProvisioning = new ServiceBusTopologySettings
                     {
                         Enabled = false


### PR DESCRIPTION
A minor change to pass the registered instances of `ServiceProvider` and `ProviderSettings` to the `ClientFactory` and `AdminClientFactory` factories.