### PR TITLE
[Host.AzureServiceBus] #349 Correlation filters

### DIFF
--- a/docs/provider_azure_servicebus.md
+++ b/docs/provider_azure_servicebus.md
@@ -217,7 +217,7 @@ mbb.Consume<TMessage>(x => x
    .MaxAutoLockRenewalDuration(TimeSpan.FromMinutes(7))
    .SubQueue(SubQueue.DeadLetter)
    .PrefetchCount(10)
-   .SubscriptionSqlFilter("1=1") // ASB subscription SQL filters can also be created - see topology creation section
+   .SubscriptionSqlFilter("1=1") // ASB subscription filters can also be created - see topology creation section
    .Instances(1));
 ```
 
@@ -342,7 +342,9 @@ When there is a need to get ahold of the `SessionId` for the message processed, 
 > Since 1.19.0
 
 ASB transport provider can automatically create the required ASB queue/topic/subscription/rule that have been declared as part of the SMB configuration.
-The provisioning happens as soon as the SMB instance is created and prior any consumers start processing messages. The creation happens only when a particular topic/queue/subscription/rule does not exist. If it exist the SMB will not alter it.
+The provisioning happens as soon as the SMB instance is created and prior to consumers starting to process messages. The creation happens only when a particular topic/queue/subscription/rule does not exist, and will not be modified if it already exists. 
+
+SMB supports both [SQL](https://learn.microsoft.com/en-us/azure/service-bus-messaging/topic-filters#sql-filters) and [Correlation](https://learn.microsoft.com/en-us/azure/service-bus-messaging/topic-filters#correlation-filters) filters through the `SubscriptionSqlFilter` and `SubscriptionCorrelationFilter` consumer builders.
 
 > In order for the ASB provisioning to work, the Azure Service Bus connection string has to use a key with the `Manage` scope permission.
 
@@ -409,7 +411,7 @@ mbb.Consume<SomeMessage>(x => x
       .Topic("some-topic")
       .WithConsumer<SomeMessageConsumer>()
       .SubscriptionName("some-service")
-      .SubscriptionSqlFilter("1=1") // this will create a rule with SQL filter
+      .SubscriptionCorrelationFilter(correlationId: "some-id") // this will create a rule to filter messages with a CorrelationId of 'some-id'
       .CreateTopicOptions((options) =>
       {
          options.RequiresDuplicateDetection = false;

--- a/src/SlimMessageBus.Host.AzureServiceBus/Config/AsbAbstractConsumerSettingsExtensions.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/Config/AsbAbstractConsumerSettingsExtensions.cs
@@ -55,12 +55,12 @@ public static class AsbAbstractConsumerSettingsExtensions
     static internal int? GetMaxConcurrentSessions(this AbstractConsumerSettings consumerSettings)
         => consumerSettings.GetOrDefault<int?>(AsbProperties.MaxConcurrentSessionsKey);
 
-    static internal IDictionary<string, SubscriptionSqlRule> GetRules(this AbstractConsumerSettings consumerSettings, bool createIfNotExists = false)
+    static internal IDictionary<string, SubscriptionRule> GetRules(this AbstractConsumerSettings consumerSettings, bool createIfNotExists = false)
     {
-        var filterByName = consumerSettings.GetOrDefault<IDictionary<string, SubscriptionSqlRule>>(AsbProperties.RulesKey);
+        var filterByName = consumerSettings.GetOrDefault<IDictionary<string, SubscriptionRule>>(AsbProperties.RulesKey);
         if (filterByName == null && createIfNotExists)
         {
-            filterByName = new Dictionary<string, SubscriptionSqlRule>();
+            filterByName = new Dictionary<string, SubscriptionRule>();
             consumerSettings.Properties[AsbProperties.RulesKey] = filterByName;
         }
         return filterByName;

--- a/src/SlimMessageBus.Host.AzureServiceBus/Config/AsbConsumerBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/Config/AsbConsumerBuilderExtensions.cs
@@ -161,6 +161,70 @@ public static class AsbConsumerBuilderExtensions
     }
 
     /// <summary>
+    /// Adds a named correlation filter to the subscription (Azure Service Bus). Setting relevant only if topology provisioning enabled.
+    /// </summary>
+    /// <typeparam name="TConsumerBuilder"></typeparam>
+    /// <param name="builder"></param>
+    /// <param name="ruleName">The name of the filter</param>
+    /// <param name="correlationId">Value to be applied as the 'CorrelationId' filter.<param>
+    /// <param name="messageId">Value to be applied as the 'MessageId' filter.<param>
+    /// <param name="to">Value to be applied as the 'To' filter.<param>
+    /// <param name="replyTo">Value to be applied as the 'ReplyTo' filter.<param>
+    /// <param name="subject">Value to be applied as the 'Subject' filter.<param>
+    /// <param name="sessionId">Value to be applied as the 'SessionId' filter.<param>
+    /// <param name="replyToSessionId">Value to be applied as the 'ReplyToSessionId' filter.<param>
+    /// <param name="contentType">Value to be applied as the 'ContentType' filter.<param></param>
+    /// <param name="applicationProperties">Filters to be applied to application specific properties.</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static TConsumerBuilder SubscriptionCorrelationFilter<TConsumerBuilder>(
+        this TConsumerBuilder builder,
+        string ruleName = "default",
+        string correlationId = "",
+        string messageId = "",
+        string to = "",
+        string replyTo = "",
+        string subject = "",
+        string sessionId = "",
+        string replyToSessionId = "",
+        string contentType = "",
+        IDictionary<string, object> applicationProperties = null)
+        where TConsumerBuilder : IAbstractConsumerBuilder
+    {
+        if (builder is null) throw new ArgumentNullException(nameof(builder));
+
+        if (string.IsNullOrWhiteSpace(correlationId)
+            && string.IsNullOrWhiteSpace(messageId)
+            && string.IsNullOrWhiteSpace(to)
+            && string.IsNullOrWhiteSpace(replyTo)
+            && string.IsNullOrWhiteSpace(subject)
+            && string.IsNullOrWhiteSpace(sessionId)
+            && string.IsNullOrWhiteSpace(replyToSessionId)
+            && string.IsNullOrWhiteSpace(contentType)
+            && (applicationProperties == null || applicationProperties?.Count == 0))
+        {
+            throw new ArgumentException("At least one property must contain a value to use as a filter");
+        }
+
+        var filterByName = builder.ConsumerSettings.GetRules(createIfNotExists: true);
+        filterByName[ruleName] = new SubscriptionCorrelationRule
+        {
+            Name = ruleName,
+            CorrelationId = correlationId,
+            MessageId = messageId,
+            To = to,
+            ReplyTo = replyTo,
+            Subject = subject,
+            SessionId = sessionId,
+            ReplyToSessionId = replyToSessionId,
+            ContentType = contentType,
+            ApplicationProperties = applicationProperties
+        };
+
+        return builder;
+    }
+
+    /// <summary>
     /// <see cref="CreateQueueOptions"/> when the ASB queue does not exist and needs to be created
     /// </summary>
     /// <typeparam name="TConsumerBuilder"></typeparam>

--- a/src/SlimMessageBus.Host.AzureServiceBus/Config/SubscriptionCorrelationRule.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/Config/SubscriptionCorrelationRule.cs
@@ -1,0 +1,14 @@
+﻿namespace SlimMessageBus.Host.AzureServiceBus;
+
+public record SubscriptionCorrelationRule : SubscriptionRule
+{
+    public string CorrelationId { get; set; }
+    public string MessageId { get; set; }
+    public string To { get; set; }
+    public string ReplyTo { get; set; }
+    public string Subject { get; set; }
+    public string SessionId { get; set; }
+    public string ReplyToSessionId { get; set; }
+    public string ContentType { get; set; }
+    public IDictionary<string, object> ApplicationProperties { get; set; }
+}

--- a/src/SlimMessageBus.Host.AzureServiceBus/Config/SubscriptionRule.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/Config/SubscriptionRule.cs
@@ -1,0 +1,6 @@
+﻿namespace SlimMessageBus.Host.AzureServiceBus;
+
+public abstract record SubscriptionRule
+{
+    public string Name { get; set; }
+}

--- a/src/SlimMessageBus.Host.AzureServiceBus/Config/SubscriptionSqlFilter.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/Config/SubscriptionSqlFilter.cs
@@ -1,8 +1,7 @@
 ﻿namespace SlimMessageBus.Host.AzureServiceBus;
 
-public record SubscriptionSqlRule
+public record SubscriptionSqlRule : SubscriptionRule
 {
-    public string Name { get; set; }
     public string SqlFilter { get; set; }
     public string SqlAction { get; set; }
 }


### PR DESCRIPTION
[Correlation filters](https://learn.microsoft.com/en-us/azure/service-bus-messaging/topic-filters#correlation-filters) are more efficient then SQL filters and are the preferred way to implement filtering when the features of SQL rule filters are not required.

```c#
mbb.Consume<SomeMessage>(x => x
      .Topic("some-topic")
      .WithConsumer<SomeMessageConsumer>()
      .SubscriptionName("some-service")
      .SubscriptionCorrelationFilter(correlationId: "some-correlation-id", contentType: "application/json")
      .CreateTopicOptions((options) =>
      {
         options.RequiresDuplicateDetection = false;
      })
   );
```

