### PR TITLE
[Host] Abandon/dead letter (#356)

### DIFF
--- a/docs/intro.t.md
+++ b/docs/intro.t.md
@@ -1067,10 +1067,11 @@ The returned `ConsumerErrorHandlerResult` object is used to override the executi
 
 | Result              | Description                                                                                                                                                                                                                 |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Abandon             | The message should be sent to the dead letter queue/exchange. **Not supported by all transports.**                                                                                                                          |
 | Failure             | The message failed to be processed and should be returned to the queue                                                                                                                                                      |
 | Success             | The pipeline must treat the message as having been processed successfully                                                                                                                                                   |
 | SuccessWithResponse | The pipeline to treat the message as having been processed successfully, returning the response to the request/response invocation ([IRequestResponseBus<T>](../src/SlimMessageBus/RequestResponse/IRequestResponseBus.cs)) |
-| Retry               | Re-create and execute the pipeline (including the message scope when using [per-message DI container scopes](#per-message-di-container-scope)) |
+| Retry               | Re-create and execute the pipeline (including the message scope when using [per-message DI container scopes](#per-message-di-container-scope))                                                                              |
 
 To enable SMB to recognize the error handler, it must be registered within the Microsoft Dependency Injection (MSDI) framework:
 
@@ -1097,8 +1098,35 @@ Transport plugins provide specialized error handling interfaces. Examples includ
 
 This approach allows for transport-specific error handling, ensuring that specialized handlers can be prioritized.
 
-Sample retry with exponential back-off (using the [ConsumerErrorHandler](../src/SlimMessageBus.Host/Consumer/ErrorHandling/ConsumerErrorHandler.cs) abstract implementation):
 
+### Abandon
+#### Azure Service Bus
+The Azure Service Bus transport has full support for abandoning messages to the dead letter queue.
+
+#### RabbitMQ
+Abandon will issue a `Nack` with `requeue: false`.
+
+#### Other transports
+No other transports currently support `Abandon` and calling `Abandon` will result in `NotSupportedException` being thrown.
+
+### Failure
+#### RabbitMQ
+While RabbitMQ supports dead letter exchanges, SMB's default implementation is not to requeue messages on `Failure`. If requeuing is required, it can be enabled by setting `RequeueOnFailure()` when configuring a consumer/handler. 
+
+Please be aware that as RabbitMQ does not have a maximum delivery count and enabling requeue may result in an infinite message loop. When `RequeueOnFailure()` has been set, it is the developer's responsibility to configure an appropriate `IConsumerErrorHandler` that will `Abandon` all non-transient exceptions.
+
+```cs
+.Handle<EchoRequest, EchoResponse>(x => x
+    .Queue("echo-request-handler")
+    .ExchangeBinding("test-echo")
+    .DeadLetterExchange("echo-request-handler-dlq")
+    // requeue a message on failure
+    .RequeueOnFailure()
+    .WithHandler<EchoRequestHandler>())
+```
+
+### Example usage
+Retry with exponential back-off and short-curcuit dead letter on non-transient exceptions (using the [ConsumerErrorHandler](../src/SlimMessageBus.Host/Consumer/ErrorHandling/ConsumerErrorHandler.cs) abstract implementation):
 ```cs
 public class RetryHandler<T> : ConsumerErrorHandler<T>
 {
@@ -1106,6 +1134,11 @@ public class RetryHandler<T> : ConsumerErrorHandler<T>
 
     public override async Task<ConsumerErrorHandlerResult> OnHandleError(T message, IConsumerContext consumerContext, Exception exception, int attempts)
     {
+        if (!IsTranientException(exception))
+        {
+          return Abandon();
+        }
+
         if (attempts < 3)
         {
             var delay = (attempts * 1000) + (_random.Next(1000) - 500);
@@ -1115,9 +1148,18 @@ public class RetryHandler<T> : ConsumerErrorHandler<T>
 
         return Failure();
     }
+
+    private static bool IsTransientException(Exception exception)
+    {
+        while (exception is not SqlException && exception.InnerException != null)
+        {
+            exception = exception.InnerException;
+        }
+
+        return exception is SqlException { Number: -2 or 1205 }; // Timeout or deadlock
+    }
 }
 ```
-
 ## Logging
 
 SlimMessageBus uses [Microsoft.Extensions.Logging.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions):

--- a/src/SlimMessageBus.Host.AmazonSQS/Consumer/ISqsConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host.AmazonSQS/Consumer/ISqsConsumerErrorHandler.cs
@@ -2,4 +2,4 @@
 
 public interface ISqsConsumerErrorHandler<in T> : IConsumerErrorHandler<T>;
 
-public abstract class SqsConsumerErrorHandler<T> : ConsumerErrorHandler<T>;
+public abstract class SqsConsumerErrorHandler<T> : ConsumerErrorHandler<T>, ISqsConsumerErrorHandler<T>;

--- a/src/SlimMessageBus.Host.AmazonSQS/Consumer/SqsBaseConsumer.cs
+++ b/src/SlimMessageBus.Host.AmazonSQS/Consumer/SqsBaseConsumer.cs
@@ -116,6 +116,11 @@ public abstract class SqsBaseConsumer : AbstractConsumer
                         .ToDictionary(x => x.Key, x => HeaderSerializer.Deserialize(x.Key, x.Value));
 
                     var r = await MessageProcessor.ProcessMessage(message, messageHeaders, cancellationToken: CancellationToken).ConfigureAwait(false);
+                    if (r.Result == ProcessResult.Abandon)
+                    {
+                        throw new NotSupportedException("Transport does not support abandoning messages");
+                    }
+
                     if (r.Exception != null)
                     {
                         Logger.LogError(r.Exception, "Message processing error - Queue: {Queue}, MessageId: {MessageId}", Path, message.MessageId);

--- a/src/SlimMessageBus.Host.AzureEventHub/Consumer/EhPartitionConsumer.cs
+++ b/src/SlimMessageBus.Host.AzureEventHub/Consumer/EhPartitionConsumer.cs
@@ -42,6 +42,11 @@ public abstract class EhPartitionConsumer
 
         var headers = GetHeadersFromTransportMessage(args.Data);
         var r = await MessageProcessor.ProcessMessage(args.Data, headers, cancellationToken: args.CancellationToken).ConfigureAwait(false);
+        if (r.Result == ProcessResult.Abandon)
+        {
+            throw new NotSupportedException("Transport does not support abandoning messages");
+        }
+
         if (r.Exception != null)
         {
             // Note: The OnMessageFaulted was called at this point by the MessageProcessor.

--- a/src/SlimMessageBus.Host.AzureEventHub/Consumer/IEventHubConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host.AzureEventHub/Consumer/IEventHubConsumerErrorHandler.cs
@@ -2,4 +2,4 @@
 
 public interface IEventHubConsumerErrorHandler<in T> : IConsumerErrorHandler<T>;
 
-public abstract class EventHubConsumerErrorHandler<T> : ConsumerErrorHandler<T>;
+public abstract class EventHubConsumerErrorHandler<T> : ConsumerErrorHandler<T>, IEventHubConsumerErrorHandler<T>;

--- a/src/SlimMessageBus.Host.AzureServiceBus/Consumer/IServiceBusConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/Consumer/IServiceBusConsumerErrorHandler.cs
@@ -2,4 +2,4 @@
 
 public interface IServiceBusConsumerErrorHandler<in T> : IConsumerErrorHandler<T>;
 
-public abstract class ServiceBusConsumerErrorHandler<T> : ConsumerErrorHandler<T>;
+public abstract class ServiceBusConsumerErrorHandler<T> : ConsumerErrorHandler<T>, IServiceBusConsumerErrorHandler<T>;

--- a/src/SlimMessageBus.Host.Kafka/Consumer/IKafkaConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/IKafkaConsumerErrorHandler.cs
@@ -2,4 +2,4 @@
 
 public interface IKafkaConsumerErrorHandler<in T> : IConsumerErrorHandler<T>;
 
-public abstract class KafkaConsumerErrorHandler<T> : ConsumerErrorHandler<T>;
+public abstract class KafkaConsumerErrorHandler<T> : ConsumerErrorHandler<T>, IKafkaConsumerErrorHandler<T>;

--- a/src/SlimMessageBus.Host.Kafka/Consumer/KafkaPartitionConsumer.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/KafkaPartitionConsumer.cs
@@ -115,6 +115,11 @@ public abstract class KafkaPartitionConsumer : IKafkaPartitionConsumer
             }
 
             var r = await _messageProcessor.ProcessMessage(message, messageHeaders, cancellationToken: _cancellationTokenSource.Token).ConfigureAwait(false);
+            if (r.Result == ProcessResult.Abandon)
+            {
+                throw new NotSupportedException("Transport does not support abandoning messages");
+            }
+
             if (r.Exception != null)
             {
                 // The IKafkaConsumerErrorHandler and OnMessageFaulted was called at this point by the MessageProcessor.

--- a/src/SlimMessageBus.Host.Memory/Consumers/IMemoryConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host.Memory/Consumers/IMemoryConsumerErrorHandler.cs
@@ -2,4 +2,4 @@
 
 public interface IMemoryConsumerErrorHandler<in T> : IConsumerErrorHandler<T>;
 
-public abstract class MemoryConsumerErrorHandler<T> : ConsumerErrorHandler<T>;
+public abstract class MemoryConsumerErrorHandler<T> : ConsumerErrorHandler<T>, IMemoryConsumerErrorHandler<T>;

--- a/src/SlimMessageBus.Host.Memory/MemoryMessageBus.cs
+++ b/src/SlimMessageBus.Host.Memory/MemoryMessageBus.cs
@@ -158,6 +158,11 @@ public class MemoryMessageBus : MessageBusBase<MemoryMessageBusSettings>
         var serviceProvider = targetBus?.ServiceProvider ?? Settings.ServiceProvider;
         // Execute the message processor in synchronous manner
         var r = await messageProcessor.ProcessMessage(transportMessage, messageHeadersReadOnly, currentServiceProvider: serviceProvider, cancellationToken: cancellationToken);
+        if (r.Result == ProcessResult.Abandon)
+        {
+            throw new NotSupportedException("Transport does not support abandoning messages");
+        }
+
         if (r.Exception != null)
         {
             // We want to pass the same exception to the sender as it happened in the handler/consumer

--- a/src/SlimMessageBus.Host.Mqtt/IMqttConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host.Mqtt/IMqttConsumerErrorHandler.cs
@@ -2,4 +2,4 @@
 
 public interface IMqttConsumerErrorHandler<in T> : IConsumerErrorHandler<T>;
 
-public abstract class MqttConsumerErrorHandler<T> : ConsumerErrorHandler<T>;
+public abstract class MqttConsumerErrorHandler<T> : ConsumerErrorHandler<T>, IMqttConsumerErrorHandler<T>;

--- a/src/SlimMessageBus.Host.Nats/INatsConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host.Nats/INatsConsumerErrorHandler.cs
@@ -2,4 +2,4 @@
 
 public interface INatsConsumerErrorHandler<in T> : IConsumerErrorHandler<T>;
 
-public abstract class NatsConsumerErrorHandler<T> : ConsumerErrorHandler<T>;
+public abstract class NatsConsumerErrorHandler<T> : ConsumerErrorHandler<T>, INatsConsumerErrorHandler<T>;

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqConsumerBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqConsumerBuilderExtensions.cs
@@ -118,5 +118,19 @@ public static class RabbitMqConsumerBuilderExtensions
         builder.ConsumerSettings.Properties[RabbitMqProperties.MessageAcknowledgementMode] = mode;
         return builder;
     }
-}
 
+    /// <summary>
+    /// <para>Requeues a message on failure. Abandoned messages will not be requeued.</para>
+    /// <para>This may lead to an infinite loop if the reason for the failure is not transient. Responsibility lies with the developer to ensure that this flow does not occur.</para>
+    /// </summary>
+    /// <typeparam name="TConsumerBuilder"></typeparam>
+    /// <param name="builder"></param>
+    /// <param name="mode"></param>
+    /// <returns></returns>
+    public static TConsumerBuilder RequeueOnFailure<TConsumerBuilder>(this TConsumerBuilder builder, bool state = true)
+       where TConsumerBuilder : AbstractConsumerBuilder
+    {
+        builder.ConsumerSettings.Properties[RabbitMqProperties.ReqeueOnFailure] = state;
+        return builder;
+    }
+}

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqHasProviderExtensions.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqHasProviderExtensions.cs
@@ -14,6 +14,6 @@ static internal class RabbitMqHasProviderExtensions
     public static string GetBindingRoutingKey(this AbstractConsumerSettings c, HasProviderExtensions settings = null)
         => c.GetOrDefault<string>(RabbitMqProperties.BindingRoutingKey, settings, null);
 
-    public static string GetExchageType(this ProducerSettings p, HasProviderExtensions settings = null)
+    public static string GetExchangeType(this ProducerSettings p, HasProviderExtensions settings = null)
         => p.GetOrDefault<string>(RabbitMqProperties.ExchangeType, settings, null);
 }

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqMessageBusBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqMessageBusBuilderExtensions.cs
@@ -14,8 +14,8 @@ public static class RabbitMqMessageBusBuilderExtensions
         if (mbb == null) throw new ArgumentNullException(nameof(mbb));
         if (configure == null) throw new ArgumentNullException(nameof(configure));
 
-        var providerSettings = mbb.Settings.GetOrCreate(RabbitMqProperties.ProvderSettings, () => new RabbitMqMessageBusSettings());
-        
+        var providerSettings = mbb.Settings.GetOrCreate(RabbitMqProperties.ProviderSettings, () => new RabbitMqMessageBusSettings());
+
         configure(providerSettings);
 
         return mbb.WithProvider(settings => new RabbitMqMessageBus(settings, providerSettings));

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqProperties.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqProperties.cs
@@ -28,7 +28,9 @@ static internal class RabbitMqProperties
 
     public static readonly string Message = $"RabbitMQ_{nameof(Message)}";
 
-    public static readonly string ProvderSettings = $"RabbitMQ_{nameof(ProvderSettings)}";
+    public static readonly string ProviderSettings = $"RabbitMQ_{nameof(ProviderSettings)}";
 
     public static readonly string MessageAcknowledgementMode = $"RabbitMQ_{nameof(MessageAcknowledgementMode)}";
+
+    public static readonly string ReqeueOnFailure = $"RabbitMQ_{nameof(ReqeueOnFailure)}";
 }

--- a/src/SlimMessageBus.Host.RabbitMQ/Consumers/IRabbitMqConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Consumers/IRabbitMqConsumerErrorHandler.cs
@@ -2,4 +2,4 @@
 
 public interface IRabbitMqConsumerErrorHandler<in T> : IConsumerErrorHandler<T>;
 
-public abstract class RabbitMqConsumerErrorHandler<T> : ConsumerErrorHandler<T>;
+public abstract class RabbitMqConsumerErrorHandler<T> : ConsumerErrorHandler<T>, IRabbitMqConsumerErrorHandler<T>;

--- a/src/SlimMessageBus.Host.RabbitMQ/Consumers/RabbitMqAutoAcknowledgeMessageProcessor.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Consumers/RabbitMqAutoAcknowledgeMessageProcessor.cs
@@ -7,17 +7,33 @@
 /// <param name="logger"></param>
 /// <param name="acknowledgementMode"></param>
 /// <param name="consumer"></param>
-internal sealed class RabbitMqAutoAcknowledgeMessageProcessor(IMessageProcessor<BasicDeliverEventArgs> target,
-                                                       ILogger logger,
-                                                       RabbitMqMessageAcknowledgementMode acknowledgementMode,
-                                                       IRabbitMqConsumer consumer)
-    : IMessageProcessor<BasicDeliverEventArgs>, IDisposable
+internal sealed class RabbitMqAutoAcknowledgeMessageProcessor : IMessageProcessor<BasicDeliverEventArgs>, IDisposable
 {
-    public IReadOnlyCollection<AbstractConsumerSettings> ConsumerSettings => target.ConsumerSettings;
+    private readonly IMessageProcessor<BasicDeliverEventArgs> _target;
+    private readonly ILogger _logger;
+    private readonly RabbitMqMessageAcknowledgementMode _acknowledgementMode;
+    private readonly IRabbitMqConsumer _consumer;
+    private readonly bool _requeueOnFailure;
+
+    public RabbitMqAutoAcknowledgeMessageProcessor(
+        IMessageProcessor<BasicDeliverEventArgs> target,
+        ILogger logger,
+        RabbitMqMessageAcknowledgementMode acknowledgementMode,
+        IRabbitMqConsumer consumer)
+    {
+        _target = target;
+        _logger = logger;
+        _acknowledgementMode = acknowledgementMode;
+        _consumer = consumer;
+
+        _requeueOnFailure = _target.ConsumerSettings?.All(x => x.GetOrDefault(RabbitMqProperties.ReqeueOnFailure, false)) ?? false;
+    }
+
+    public IReadOnlyCollection<AbstractConsumerSettings> ConsumerSettings => _target.ConsumerSettings;
 
     public void Dispose()
     {
-        if (target is IDisposable targetDisposable)
+        if (_target is IDisposable targetDisposable)
         {
             targetDisposable.Dispose();
         }
@@ -25,22 +41,26 @@ internal sealed class RabbitMqAutoAcknowledgeMessageProcessor(IMessageProcessor<
 
     public async Task<ProcessMessageResult> ProcessMessage(BasicDeliverEventArgs transportMessage, IReadOnlyDictionary<string, object> messageHeaders, IDictionary<string, object> consumerContextProperties = null, IServiceProvider currentServiceProvider = null, CancellationToken cancellationToken = default)
     {
-        var r = await target.ProcessMessage(transportMessage, messageHeaders: messageHeaders, consumerContextProperties: consumerContextProperties, cancellationToken: cancellationToken);
-
-        if (acknowledgementMode == RabbitMqMessageAcknowledgementMode.ConfirmAfterMessageProcessingWhenNoManualConfirmMade)
+        var r = await _target.ProcessMessage(transportMessage, messageHeaders: messageHeaders, consumerContextProperties: consumerContextProperties, cancellationToken: cancellationToken);
+        if (_acknowledgementMode == RabbitMqMessageAcknowledgementMode.ConfirmAfterMessageProcessingWhenNoManualConfirmMade)
         {
             // Acknowledge after processing
-            var confirmOption = r.Exception != null
-                ? RabbitMqMessageConfirmOptions.Nack // NAck after processing when message fails (unless the user already acknowledged in any way).
-                : RabbitMqMessageConfirmOptions.Ack; // Acknowledge after processing
+            var confirmOption = r.Result switch
+            {
+                ProcessResult.Abandon => RabbitMqMessageConfirmOptions.Nack,                                                               // NAck after processing when message fails with non-transient exception (unless the user already acknowledged in any way).
+                ProcessResult.Fail when (_requeueOnFailure) => RabbitMqMessageConfirmOptions.Nack | RabbitMqMessageConfirmOptions.Requeue, // Re-queue after processing on transient failure
+                ProcessResult.Fail when (!_requeueOnFailure) => RabbitMqMessageConfirmOptions.Nack,                                        // Fail after processing failure (no re-queue)
+                ProcessResult.Success => RabbitMqMessageConfirmOptions.Ack,                                                                // Acknowledge after processing
+                _ => throw new NotImplementedException()
+            };
 
-            consumer.ConfirmMessage(transportMessage, confirmOption, consumerContextProperties);
+            _consumer.ConfirmMessage(transportMessage, confirmOption, consumerContextProperties);
         }
 
         if (r.Exception != null)
         {
             // We rely on the IMessageProcessor to execute the ConsumerErrorHandler<T>, but if it's not registered in the DI, it fails, or there is another fatal error then the message will be lost.
-            logger.LogError(r.Exception, "Exchange {Exchange} - Queue {Queue}: Error processing message {Message}, delivery tag {DeliveryTag}", transportMessage.Exchange, consumer.QueueName, transportMessage, transportMessage.DeliveryTag);
+            _logger.LogError(r.Exception, "Exchange {Exchange} - Queue {Queue}: Error processing message {Message}, delivery tag {DeliveryTag}", transportMessage.Exchange, _consumer.QueueName, transportMessage, transportMessage.DeliveryTag);
         }
         return r;
     }

--- a/src/SlimMessageBus.Host.RabbitMQ/Consumers/RabbitMqConsumer.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Consumers/RabbitMqConsumer.cs
@@ -36,7 +36,7 @@ public class RabbitMqConsumer : AbstractRabbitMqConsumer, IRabbitMqConsumer
                 messageBus,
                 path: queueName,
                 responseProducer: messageBus,
-            messageProvider: messageProvider,
+                messageProvider: messageProvider,
                 consumerContextInitializer: InitializeConsumerContext,
                 consumerErrorHandlerOpenGenericType: typeof(IRabbitMqConsumerErrorHandler<>));
 
@@ -44,7 +44,7 @@ public class RabbitMqConsumer : AbstractRabbitMqConsumer, IRabbitMqConsumer
 
             // pick the maximum number of instances
             var instances = consumers.Max(x => x.Instances);
-            // For a given rabbit channel, there is only 1 task that dispatches messages. We want to be be able to let each SMB consume process within its own task (1 or more)
+            // For a given rabbit channel, there is only 1 task that dispatches messages. We want to be able to let each SMB consume process within its own task (1 or more)
             messageProcessor = new ConcurrentMessageProcessorDecorator<BasicDeliverEventArgs>(instances, loggerFactory, messageProcessor);
 
             return messageProcessor;

--- a/src/SlimMessageBus.Host.RabbitMQ/Consumers/RabbitMqResponseConsumer.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Consumers/RabbitMqResponseConsumer.cs
@@ -3,6 +3,7 @@
 public class RabbitMqResponseConsumer : AbstractRabbitMqConsumer
 {
     private readonly IMessageProcessor<BasicDeliverEventArgs> _messageProcessor;
+    private readonly bool _requeueOnFailure;
 
     protected override RabbitMqMessageAcknowledgementMode AcknowledgementMode => RabbitMqMessageAcknowledgementMode.ConfirmAfterMessageProcessingWhenNoManualConfirmMade;
 
@@ -18,19 +19,30 @@ public class RabbitMqResponseConsumer : AbstractRabbitMqConsumer
         : base(loggerFactory.CreateLogger<RabbitMqResponseConsumer>(), channel, queueName, headerValueConverter)
     {
         _messageProcessor = new ResponseMessageProcessor<BasicDeliverEventArgs>(loggerFactory, requestResponseSettings, messageProvider, pendingRequestStore, currentTimeProvider);
+        _requeueOnFailure = requestResponseSettings.GetOrDefault(RabbitMqProperties.ReqeueOnFailure, false);
     }
 
     protected override async Task<Exception> OnMessageReceived(Dictionary<string, object> messageHeaders, BasicDeliverEventArgs transportMessage)
     {
         var r = await _messageProcessor.ProcessMessage(transportMessage, messageHeaders: messageHeaders, cancellationToken: CancellationToken);
-        if (r.Exception == null)
+        switch (r.Result)
         {
-            AckMessage(transportMessage);
+            case ProcessResult.Abandon:
+                NackMessage(transportMessage, requeue: false);
+                break;
+
+            case ProcessResult.Fail:
+                NackMessage(transportMessage, requeue: _requeueOnFailure);
+                break;
+
+            case ProcessResult.Success:
+                AckMessage(transportMessage);
+                break;
+
+            default:
+                throw new NotImplementedException();
         }
-        else
-        {
-            NackMessage(transportMessage, requeue: false);
-        }
+
         return r.Exception;
     }
 }

--- a/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBusSettingsValidationService.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBusSettingsValidationService.cs
@@ -32,7 +32,7 @@ internal class RabbitMqMessageBusSettingsValidationService : DefaultMessageBusSe
         if (routingKeyProvider == null)
         {
             // Requirement for the routing key depends on the ExchangeType
-            var exchangeType = producerSettings.GetExchageType(ProviderSettings);
+            var exchangeType = producerSettings.GetExchangeType(ProviderSettings);
             if (exchangeType == global::RabbitMQ.Client.ExchangeType.Direct || exchangeType == global::RabbitMQ.Client.ExchangeType.Topic)
             {
                 ThrowProducerFieldNotSet(producerSettings, nameof(RabbitMqProducerBuilderExtensions.RoutingKeyProvider), $"is neither provided on the producer for exchange {producerSettings.DefaultPath} nor a default provider exists at the bus level (check that .{nameof(RabbitMqProducerBuilderExtensions.RoutingKeyProvider)}() exists on the producer or bus level). Exchange type {exchangeType} requires the producer to has a routing key provider.");
@@ -75,6 +75,5 @@ internal class RabbitMqMessageBusSettingsValidationService : DefaultMessageBusSe
                 ThrowRequestResponseFieldNotSet(nameof(RabbitMqConsumerBuilderExtensions.Queue));
             }
         }
-
     }
 }

--- a/src/SlimMessageBus.Host.Redis/Consumers/IRedisConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host.Redis/Consumers/IRedisConsumerErrorHandler.cs
@@ -2,4 +2,4 @@
 
 public interface IRedisConsumerErrorHandler<in T> : IConsumerErrorHandler<T>;
 
-public abstract class RedisConsumerErrorHandler<T> : ConsumerErrorHandler<T>;
+public abstract class RedisConsumerErrorHandler<T> : ConsumerErrorHandler<T>, IRedisConsumerErrorHandler<T>;

--- a/src/SlimMessageBus.Host.Redis/Consumers/RedisListCheckerConsumer.cs
+++ b/src/SlimMessageBus.Host.Redis/Consumers/RedisListCheckerConsumer.cs
@@ -74,6 +74,11 @@ public class RedisListCheckerConsumer : AbstractConsumer, IRedisConsumer
                             var processor = queue.Processors[i];
 
                             var r = await processor.ProcessMessage(transportMessage, transportMessage.Headers, cancellationToken: CancellationToken).ConfigureAwait(false);
+                            if (r.Result == ProcessResult.Abandon)
+                            {
+                                throw new NotSupportedException("Transport does not support abandoning messages");
+                            }
+
                             if (r.Exception != null)
                             {
                                 Logger.LogError(r.Exception, "Error occurred while processing the list item on {Queue}", queue.Name);

--- a/src/SlimMessageBus.Host.Redis/Consumers/RedisTopicConsumer.cs
+++ b/src/SlimMessageBus.Host.Redis/Consumers/RedisTopicConsumer.cs
@@ -45,6 +45,11 @@ public class RedisTopicConsumer : AbstractConsumer, IRedisConsumer
             var messageWithHeaders = (MessageWithHeaders)_envelopeSerializer.Deserialize(typeof(MessageWithHeaders), m.Message);
 
             var r = await _messageProcessor.ProcessMessage(messageWithHeaders, messageWithHeaders.Headers, cancellationToken: CancellationToken);
+            if (r.Result == ProcessResult.Abandon)
+            {
+                throw new NotSupportedException("Transport does not support abandoning messages");
+            }
+
             exception = r.Exception;
         }
         catch (Exception e)

--- a/src/SlimMessageBus.Host/Consumer/ErrorHandling/ConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host/Consumer/ErrorHandling/ConsumerErrorHandler.cs
@@ -7,7 +7,8 @@ public abstract class ConsumerErrorHandler<T> : BaseConsumerErrorHandler, IConsu
 
 public abstract class BaseConsumerErrorHandler
 {
-    public static ConsumerErrorHandlerResult Failure() => ConsumerErrorHandlerResult.Failure;
-    public static ConsumerErrorHandlerResult Retry() => ConsumerErrorHandlerResult.Retry;
-    public static ConsumerErrorHandlerResult Success(object response = null) => response == null ? ConsumerErrorHandlerResult.Success : ConsumerErrorHandlerResult.SuccessWithResponse(response);
+    public virtual ConsumerErrorHandlerResult Abandon() => ConsumerErrorHandlerResult.Abandon;
+    public virtual ConsumerErrorHandlerResult Failure() => ConsumerErrorHandlerResult.Failure;
+    public virtual ConsumerErrorHandlerResult Retry() => ConsumerErrorHandlerResult.Retry;
+    public virtual ConsumerErrorHandlerResult Success(object response = null) => response == null ? ConsumerErrorHandlerResult.Success : ConsumerErrorHandlerResult.SuccessWithResponse(response);
 }

--- a/src/SlimMessageBus.Host/Consumer/ErrorHandling/ConsumerErrorHandlerResult.cs
+++ b/src/SlimMessageBus.Host/Consumer/ErrorHandling/ConsumerErrorHandlerResult.cs
@@ -4,40 +4,41 @@ public record ConsumerErrorHandlerResult
 {
     private static readonly object _noResponse = new();
 
-    private ConsumerErrorHandlerResult(ConsumerErrorHandlerResultEnum result, object response = null)
+    private ConsumerErrorHandlerResult(ProcessResult result, object response = null)
     {
         Result = result;
         Response = response ?? _noResponse;
     }
 
-    public ConsumerErrorHandlerResultEnum Result { get; private set; }
+    public ProcessResult Result { get; private set; }
     public object Response { get; private set; }
     public bool HasResponse => !ReferenceEquals(Response, _noResponse);
 
     /// <summary>
+    /// the message should be abandoned and placed in the dead letter queue.
+    /// </summary>
+    /// <note>
+    /// This feature is not supported by every transport.
+    /// </note>
+    public static readonly ConsumerErrorHandlerResult Abandon = new(ProcessResult.Abandon);
+
+    /// <summary>
     /// The message should be placed back into the queue.
     /// </summary>
-    public static readonly ConsumerErrorHandlerResult Failure = new(ConsumerErrorHandlerResultEnum.Fail);
+    public static readonly ConsumerErrorHandlerResult Failure = new(ProcessResult.Fail);
 
     /// <summary>
     /// The message processor should evaluate the message as having been processed successfully.
     /// </summary>
-    public static readonly ConsumerErrorHandlerResult Success = new(ConsumerErrorHandlerResultEnum.Success);
+    public static readonly ConsumerErrorHandlerResult Success = new(ProcessResult.Success);
 
     /// <summary>
     /// The message processor should evaluate the message as having been processed successfully and use the specified fallback response for the <see cref="IRequestHandler{TRequest}"/> or <see cref="IRequestHandler{TRequest, TResponse}"/>.
     /// </summary>
-    public static ConsumerErrorHandlerResult SuccessWithResponse(object response) => new(ConsumerErrorHandlerResultEnum.Success, response);
+    public static ConsumerErrorHandlerResult SuccessWithResponse(object response) => new(ProcessResult.Success, response);
 
     /// <summary>
     /// Retry processing the message without placing it back in the queue.
     /// </summary>
-    public static readonly ConsumerErrorHandlerResult Retry = new(ConsumerErrorHandlerResultEnum.Retry);
-}
-
-public enum ConsumerErrorHandlerResultEnum
-{
-    Fail,
-    Retry,
-    Success
+    public static readonly ConsumerErrorHandlerResult Retry = new(ProcessResult.Retry);
 }

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/ConcurrentMessageProcessorDecorator.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/ConcurrentMessageProcessorDecorator.cs
@@ -1,7 +1,7 @@
 ﻿namespace SlimMessageBus.Host;
 
 /// <summary>
-/// Decorator  profor <see cref="IMessageProcessor{TMessage}"> that increases the amount of messages being concurrentlycessed.
+/// Decorator for <see cref="IMessageProcessor{TMessage}"> that increases the amount of messages being concurrently processed.
 /// The expectation is that <see cref="IMessageProcessor{TMessage}.ProcessMessage(TMessage)"/> will be executed synchronously (in sequential order) by the caller on which we want to increase amount of concurrent transportMessage being processed.
 /// </summary>
 /// <typeparam name="TMessage"></typeparam>
@@ -58,7 +58,7 @@ public sealed class ConcurrentMessageProcessorDecorator<TMessage> : IMessageProc
         {
             // report the last exception
             _lastException = null;
-            return new(e, _lastExceptionSettings, null);
+            return new(ProcessResult.Fail, e, _lastExceptionSettings, null);
         }
 
         Interlocked.Increment(ref _pendingCount);
@@ -67,7 +67,7 @@ public sealed class ConcurrentMessageProcessorDecorator<TMessage> : IMessageProc
         _ = ProcessInBackground(transportMessage, messageHeaders, currentServiceProvider, consumerContextProperties, cancellationToken);
 
         // Not exception - we don't know yet
-        return new(null, null, null);
+        return new(ProcessResult.Success, null, null, null);
     }
 
     /// <summary>

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/IMessageHandler.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/IMessageHandler.cs
@@ -2,6 +2,6 @@
 
 public interface IMessageHandler
 {
-    Task<(object Response, Exception ResponseException, string RequestId)> DoHandle(object message, IReadOnlyDictionary<string, object> messageHeaders, IMessageTypeConsumerInvokerSettings consumerInvoker, object transportMessage = null, IDictionary<string, object> consumerContextProperties = null, IServiceProvider currentServiceProvider = null, CancellationToken cancellationToken = default);
+    Task<(ProcessResult Result, object Response, Exception ResponseException, string RequestId)> DoHandle(object message, IReadOnlyDictionary<string, object> messageHeaders, IMessageTypeConsumerInvokerSettings consumerInvoker, object transportMessage = null, IDictionary<string, object> consumerContextProperties = null, IServiceProvider currentServiceProvider = null, CancellationToken cancellationToken = default);
     Task<object> ExecuteConsumer(object message, IConsumerContext consumerContext, IMessageTypeConsumerInvokerSettings consumerInvoker, Type responseType);
 }

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/IMessageProcessor.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/IMessageProcessor.cs
@@ -1,10 +1,11 @@
 namespace SlimMessageBus.Host;
 
-public readonly struct ProcessMessageResult(Exception exception, AbstractConsumerSettings consumerSettings, object response)
+public readonly struct ProcessMessageResult(ProcessResult result, Exception exception, AbstractConsumerSettings consumerSettings, object response)
 {
     public Exception Exception { get; init; } = exception;
     public AbstractConsumerSettings ConsumerSettings { get; init; } = consumerSettings;
     public object Response { get; init; } = response;
+    public ProcessResult Result { get; init; } = result;
 }
 
 public interface IMessageProcessor<in TMessage>

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/ProcessResult.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/ProcessResult.cs
@@ -1,0 +1,9 @@
+﻿namespace SlimMessageBus.Host;
+
+public enum ProcessResult
+{
+    Abandon,
+    Fail,
+    Retry,
+    Success
+}

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/ResponseMessageProcessor.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/ResponseMessageProcessor.cs
@@ -1,8 +1,6 @@
 namespace SlimMessageBus.Host;
 
-public abstract class ResponseMessageProcessor
-{
-}
+public abstract class ResponseMessageProcessor;
 
 /// <summary>
 /// The <see cref="IMessageProcessor{TMessage}"/> implementation that processes the responses arriving to the bus.
@@ -48,7 +46,9 @@ public class ResponseMessageProcessor<TTransportMessage> : ResponseMessageProces
             // We can only continue and process all messages in the lease    
             ex = e;
         }
-        return Task.FromResult(new ProcessMessageResult(ex, _requestResponseSettings, null));
+
+        var result = ex == null ? ProcessResult.Success : ProcessResult.Fail;
+        return Task.FromResult(new ProcessMessageResult(result, ex, _requestResponseSettings, null));
     }
 
     /// <summary>
@@ -117,5 +117,4 @@ public class ResponseMessageProcessor<TTransportMessage> : ResponseMessageProces
 
         return null;
     }
-
 }

--- a/src/Tests/SlimMessageBus.Host.Memory.Test/Consumers/ConcurrentMessageProcessorQueueTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Memory.Test/Consumers/ConcurrentMessageProcessorQueueTests.cs
@@ -20,7 +20,7 @@ public class ConcurrentMessageProcessorQueueTests
         static async Task<ProcessMessageResult> ProcessMessageFake(object transportMessage, IReadOnlyDictionary<string, object> messageHeaders, IDictionary<string, object> consumerContextProperties, IServiceProvider currentServiceProvider, CancellationToken cancellationToken)
         {
             await Task.Delay(500, cancellationToken);
-            return new ProcessMessageResult(null, null, null);
+            return new ProcessMessageResult(ProcessResult.Success, null, null, null);
         }
 
         messageProcessor

--- a/src/Tests/SlimMessageBus.Host.Memory.Test/Consumers/MessageProcessorQueueTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Memory.Test/Consumers/MessageProcessorQueueTests.cs
@@ -18,7 +18,7 @@ public class MessageProcessorQueueTests
         static async Task<ProcessMessageResult> ProcessMessageFake(object transportMessage, IReadOnlyDictionary<string, object> messageHeaders, IDictionary<string, object> consumerContextProperties, IServiceProvider currentServiceProvider, CancellationToken cancellationToken)
         {
             await Task.Delay(500, cancellationToken);
-            return new ProcessMessageResult(null, null, null);
+            return new ProcessMessageResult(ProcessResult.Success, null, null, null);
         }
 
         messageProcessor

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/Consumer/RabbitMqAutoAcknowledgeMessageProcessorTests.cs
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/Consumer/RabbitMqAutoAcknowledgeMessageProcessorTests.cs
@@ -4,16 +4,15 @@ using global::RabbitMQ.Client.Events;
 
 public class RabbitMqAutoAcknowledgeMessageProcessorTests
 {
-    private readonly Mock<IMessageProcessor<object>> _targetMock;
-    private readonly Mock<IDisposable> _targetDisposableMock;
+    private readonly Mock<IMessageProcessor<object>> _messageProcessorMock;
+    private readonly Mock<IDisposable> _messageProcessorDisposableMock;
     private readonly Mock<IRabbitMqConsumer> _consumerMock;
     private readonly BasicDeliverEventArgs _transportMessage;
-    private readonly RabbitMqAutoAcknowledgeMessageProcessor _subject;
 
     public RabbitMqAutoAcknowledgeMessageProcessorTests()
     {
-        _targetMock = new Mock<IMessageProcessor<object>>();
-        _targetDisposableMock = _targetMock.As<IDisposable>();
+        _messageProcessorMock = new Mock<IMessageProcessor<object>>();
+        _messageProcessorDisposableMock = _messageProcessorMock.As<IDisposable>();
         _consumerMock = new Mock<IRabbitMqConsumer>();
 
         _transportMessage = new BasicDeliverEventArgs
@@ -21,29 +20,36 @@ public class RabbitMqAutoAcknowledgeMessageProcessorTests
             Exchange = "exchange",
             DeliveryTag = 1
         };
-
-        _subject = new RabbitMqAutoAcknowledgeMessageProcessor(_targetMock.Object, NullLogger<RabbitMqAutoAcknowledgeMessageProcessor>.Instance, RabbitMqMessageAcknowledgementMode.ConfirmAfterMessageProcessingWhenNoManualConfirmMade, _consumerMock.Object);
     }
 
     [Fact]
     public void When_Dispose_Then_CallsDisposeOnTarget()
     {
         // arrange
+        var subject = CreateSubject();
 
         // act
-        _subject.Dispose();
+        subject.Dispose();
 
         // assert
-        _targetDisposableMock.Verify(x => x.Dispose(), Times.Once);
+        _messageProcessorDisposableMock.Verify(x => x.Dispose(), Times.Once);
     }
 
-    [Fact]
-    public async Task When_ProcessMessage_Then_AutoAcknowledge()
+    [Theory]
+    [InlineData(ProcessResult.Abandon, RabbitMqMessageConfirmOptions.Nack)]
+    [InlineData(ProcessResult.Fail, RabbitMqMessageConfirmOptions.Nack)]
+    [InlineData(ProcessResult.Success, RabbitMqMessageConfirmOptions.Ack)]
+    public async Task When_ProcessMessage_Then_AutoAcknowledge(ProcessResult processResult, RabbitMqMessageConfirmOptions expected)
     {
         // arrange
+        _messageProcessorMock
+            .Setup(x => x.ProcessMessage(It.IsAny<object>(), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<IServiceProvider>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new ProcessMessageResult(processResult, null, null, null)));
+
+        var subject = CreateSubject();
 
         // act
-        var result = await _subject.ProcessMessage(
+        var result = await subject.ProcessMessage(
             _transportMessage,
             new Dictionary<string, object>(),
             null,
@@ -53,8 +59,13 @@ public class RabbitMqAutoAcknowledgeMessageProcessorTests
         // assert
         _consumerMock.Verify(x => x.ConfirmMessage(
             _transportMessage,
-            RabbitMqMessageConfirmOptions.Ack,
+            expected,
             It.IsAny<IDictionary<string, object>>(),
             It.IsAny<bool>()), Times.Once);
+    }
+
+    private RabbitMqAutoAcknowledgeMessageProcessor CreateSubject()
+    {
+        return new RabbitMqAutoAcknowledgeMessageProcessor(_messageProcessorMock.Object, NullLogger<RabbitMqAutoAcknowledgeMessageProcessor>.Instance, RabbitMqMessageAcknowledgementMode.ConfirmAfterMessageProcessingWhenNoManualConfirmMade, _consumerMock.Object);
     }
 }

--- a/src/Tests/SlimMessageBus.Host.Test/Consumer/ConcurrentMessageProcessorDecoratorTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Consumer/ConcurrentMessageProcessorDecoratorTest.cs
@@ -41,7 +41,7 @@ public class ConcurrentMessageProcessorDecoratorTest
             .Returns(async () =>
             {
                 await Task.Delay(TimeSpan.FromSeconds(1));
-                return new(null, null, null);
+                return new(ProcessResult.Success, null, null, null);
             });
 
         var subject = new ConcurrentMessageProcessorDecorator<SomeMessage>(1, NullLoggerFactory.Instance, _messageProcessorMock.Object);
@@ -115,7 +115,7 @@ public class ConcurrentMessageProcessorDecoratorTest
 
                 // Leaving critical section
                 Interlocked.Decrement(ref currentSectionCount);
-                return new(null, null, null);
+                return new(ProcessResult.Success, null, null, null);
             });
 
         // act
@@ -147,7 +147,7 @@ public class ConcurrentMessageProcessorDecoratorTest
 
         _messageProcessorMock
             .Setup(x => x.ProcessMessage(It.IsAny<SomeMessage>(), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<IServiceProvider>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ProcessMessageResult(exception, null, null));
+            .ReturnsAsync(new ProcessMessageResult(ProcessResult.Fail, exception, null, null));
 
         var msg = new SomeMessage();
         var msgHeaders = new Dictionary<string, object>();


### PR DESCRIPTION
Added `Abandon` response to `ConsumerErrorHandlerResult` to be used by supported transports to dead letter the message. Most transports don't support the feature without some form of customised flow, but ASB and RabbitMQ both do.

***Azure Service Bus***
Implemented without restriction. Abandoned messages will be sent directly to the DLQ, failed messages will be retried until their maximum delivery count has been exceeded.

***RabbitMQ***
I don't have any experience with RabbitMQ, so I may have missed something; but the bus does not appear to limit how many times a message will be delivered if it is Nacked with requeue = true. As such, changing the code to fail with a requeue would be a dangerous breaking change as it could lead to an inifinite recursion in message processing for exisiting SMB users (unless I have missed something). 

I have left the RabbitMq processing flow intact but with the expectation that a future change will provide tracking or some other safety net for the above scenario. Do you have a better option/insight into the RabbitMQ model?

***Other transports***
A `NotSupportedException` will be thrown if `IConsumerErrorHandler` returns with an `Abandon` state.

***Application headers***
With ASB currently being the major benefactor to this change, it becomes a bit of a moot point. ASB does not support header customisation when dead lettering a message (`DeadLetterReason` and `DeadLetterErrorDescription` are both set, but that is the extent of the customization permitted).