### PR TITLE
[Host.AzureServiceBus] Modify user properties on failure / Supply reason and description on dead-letter

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1263,5 +1263,5 @@ This allows to recreate missing elements in the infrastructure without restartin
 
 ## Versions
 
-- The v3 release [migration guide](https://github.com/zarusz/SlimMessageBus/tree/release/v3).
+- The v3 release [migration guide](https://github.com/zarusz/SlimMessageBus/releases/tag/3.0.0).
 - The v2 release [migration guide](https://github.com/zarusz/SlimMessageBus/releases/tag/Host.Transport-2.0.0).

--- a/src/SlimMessageBus.Host.AzureServiceBus/Consumer/IServiceBusConsumerErrorHandler.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/Consumer/IServiceBusConsumerErrorHandler.cs
@@ -4,7 +4,19 @@ public interface IServiceBusConsumerErrorHandler<in T> : IConsumerErrorHandler<T
 
 public abstract class ServiceBusConsumerErrorHandler<T> : ConsumerErrorHandler<T>, IServiceBusConsumerErrorHandler<T>
 {
-    public ProcessResult DeadLetter() => ServiceBusProcessResult.DeadLetter;
+    public ProcessResult DeadLetter(string reason = null, string description = null)
+    {
+        return reason == null && description == null
+            ? ServiceBusProcessResult.DeadLetter
+            : new ServiceBusProcessResult.DeadLetterState(reason, description);
+    }
+
+    public ProcessResult Failure(IReadOnlyDictionary<string, object> properties)
+    {
+        return properties != null && properties.Count > 0
+            ? new ServiceBusProcessResult.FailureStateWithProperties(properties)
+            : Failure();
+    }
 }
 
 public record ServiceBusProcessResult : ProcessResult
@@ -14,5 +26,25 @@ public record ServiceBusProcessResult : ProcessResult
     /// </summary>
     public static readonly ProcessResult DeadLetter = new DeadLetterState();
 
-    public record DeadLetterState() : ProcessResult();
+    public record DeadLetterState : ProcessResult
+    {
+        public DeadLetterState(string reason = null, string description = null)
+        {
+            Reason = reason;
+            Description = description;
+        }
+
+        public string Reason { get; }
+        public string Description { get; }
+    }
+
+    public record FailureStateWithProperties : FailureState
+    {
+        public FailureStateWithProperties(IReadOnlyDictionary<string, object> properties)
+        {
+            Properties = properties;
+        }
+
+        public IReadOnlyDictionary<string, object> Properties { get; }
+    }
 }

--- a/src/SlimMessageBus/IConsumerWithContext.cs
+++ b/src/SlimMessageBus/IConsumerWithContext.cs
@@ -1,7 +1,7 @@
 ﻿namespace SlimMessageBus;
 
 /// <summary>
-/// An extension point for <see cref="IConsumer{TMessage}"/> to recieve provider specific (for current message subject to processing).
+/// An extension point for <see cref="IConsumer{TMessage}"/> to receive provider specific (for current message subject to processing).
 /// </summary>
 public interface IConsumerWithContext
 {


### PR DESCRIPTION
#358 Added support for suppliying modified user properties with using an ASB transport when using a custom `ServiceBusConsumerErrorHandler<T>` implemntation and `Failure()`.

```cs
public sealed class SampleConsumerErrorHandler<T> : ServiceBusConsumerErrorHandler<T>
{
    public override Task<ProcessResult> OnHandleError(T message, IConsumerContext consumerContext, Exception exception, int attempts)
    {
        var properties = new Dictionary<string, object>
        {
            { "Key", "value" },
            { "Attempts", attempts },
            { "SMB.Exception", exception.ToString().Substring(0, 1000) }
        };

        return Task.FromResult(Failure(properties));
    }
}
```
---
An option to supply a dead-letter reason/description when sending a message to the DLQ has also been included. If neither a reason nor description are supplied, it will fall back to the original implementation of exception type as the reason and exception message as the description.

```cs
public sealed class SampleConsumerErrorHandler<T> : ServiceBusConsumerErrorHandler<T>
{
    public override Task<ProcessResult> OnHandleError(T message, IConsumerContext consumerContext, Exception exception, int attempts)
    {
        return Task.FromResult(DeadLetter("reason", "description"));
    }
}
```
---
PS. It's great to see that v3 has escaped :)