### PR TITLE
[Host.RabbitMq] Convert ExchangeType from enum to a string

### DIFF
--- a/src/Host.Plugin.Properties.xml
+++ b/src/Host.Plugin.Properties.xml
@@ -4,7 +4,7 @@
   <Import Project="Common.NuGet.Properties.xml" />
 
   <PropertyGroup>
-    <Version>3.2.0-rc101</Version>
+    <Version>3.2.0-rc102</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
+++ b/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
@@ -6,7 +6,7 @@
     <Description>Core configuration interfaces of SlimMessageBus</Description>
     <PackageTags>SlimMessageBus</PackageTags>
     <RootNamespace>SlimMessageBus.Host</RootNamespace>
-    <Version>3.2.0-rc101</Version>
+    <Version>3.2.0-rc102</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/ExchangeType.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/ExchangeType.cs
@@ -1,24 +1,30 @@
 ﻿namespace SlimMessageBus.Host.RabbitMQ;
 
-public enum ExchangeType
+public static class ExchangeType
 {
     /// <summary>
     /// Exchange type used for AMQP direct exchanges.
     /// </summary>
-    Direct = 0,
+    public static readonly string Direct = global::RabbitMQ.Client.ExchangeType.Direct;
 
     /// <summary>
     /// Exchange type used for AMQP fanout exchanges.
     /// </summary>
-    Fanout = 1,
+    public static readonly string Fanout = global::RabbitMQ.Client.ExchangeType.Fanout;
 
     /// <summary>
     /// Exchange type used for AMQP headers exchanges.
     /// </summary>
-    Headers = 2,
+    public static readonly string Headers = global::RabbitMQ.Client.ExchangeType.Headers;
 
     /// <summary>
     /// Exchange type used for AMQP topic exchanges.
     /// </summary>
-    Topic = 3
+    public static readonly string Topic = global::RabbitMQ.Client.ExchangeType.Topic;
+
+    /// <summary>
+    /// Exchange type used for Delayed Message Plugin exchanges. 
+    /// See more: <see href="https://www.rabbitmq.com/blog/2015/04/16/scheduling-messages-with-rabbitmq#installing-the-plugin"/>
+    /// </summary>
+    public static readonly string XDelayedMessage = "x-delayed-message";
 }

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqConsumerBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqConsumerBuilderExtensions.cs
@@ -18,26 +18,26 @@ public static class RabbitMqConsumerBuilderExtensions
     {
         if (string.IsNullOrEmpty(queueName)) throw new ArgumentNullException(nameof(queueName));
 
-        builder.ConsumerSettings.Properties[RabbitMqProperties.QueueName] = queueName;
+        RabbitMqProperties.QueueName.Set(builder.ConsumerSettings, queueName);
 
         if (exclusive != null)
         {
-            builder.ConsumerSettings.Properties[RabbitMqProperties.QueueExclusive] = exclusive.Value;
+            RabbitMqProperties.QueueExclusive.Set(builder.ConsumerSettings, exclusive.Value);
         }
 
         if (durable != null)
         {
-            builder.ConsumerSettings.Properties[RabbitMqProperties.QueueDurable] = durable.Value;
+            RabbitMqProperties.QueueDurable.Set(builder.ConsumerSettings, durable.Value);
         }
 
         if (autoDelete != null)
         {
-            builder.ConsumerSettings.Properties[RabbitMqProperties.QueueAutoDelete] = autoDelete.Value;
+            RabbitMqProperties.QueueAutoDelete.Set(builder.ConsumerSettings, autoDelete.Value);
         }
 
         if (arguments != null)
         {
-            builder.ConsumerSettings.Properties[RabbitMqProperties.QueueArguments] = arguments;
+            RabbitMqProperties.QueueArguments.Set(builder.ConsumerSettings, arguments);
         }
 
         return builder;
@@ -58,7 +58,7 @@ public static class RabbitMqConsumerBuilderExtensions
         if (string.IsNullOrEmpty(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
 
         builder.ConsumerSettings.Path = exchangeName;
-        builder.ConsumerSettings.Properties[RabbitMqProperties.BindingRoutingKey] = routingKey;
+        RabbitMqProperties.BindingRoutingKey.Set(builder.ConsumerSettings, routingKey);
 
         return builder;
     }
@@ -70,36 +70,36 @@ public static class RabbitMqConsumerBuilderExtensions
     /// <typeparam name="TConsumerBuilder"></typeparam>
     /// <param name="builder"></param>
     /// <param name="exchangeName">Will set the "x-dead-letter-exchange" argument on the queue</param>
-    /// <param name="exchangeType">Type of the exchange, when provided SMB will attempt to provision the exchange</param>
+    /// <param name="exchangeType">Type of the exchange, when provided SMB will attempt to provision the exchange. See <see cref="ExchangeType"/>.</param>
     /// <param name="durable"></param>
     /// <param name="autoDelete"></param>
     /// <param name="routingKey">Will set the "x-dead-letter-routing-key" argument on the queue</param>
     /// <returns></returns>
-    public static TConsumerBuilder DeadLetterExchange<TConsumerBuilder>(this TConsumerBuilder builder, string exchangeName, ExchangeType? exchangeType = null, bool? durable = null, bool? autoDelete = null, string routingKey = null)
+    public static TConsumerBuilder DeadLetterExchange<TConsumerBuilder>(this TConsumerBuilder builder, string exchangeName, string exchangeType = null, bool? durable = null, bool? autoDelete = null, string routingKey = null)
         where TConsumerBuilder : AbstractConsumerBuilder
     {
         if (string.IsNullOrEmpty(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
 
-        builder.ConsumerSettings.Properties[RabbitMqProperties.DeadLetterExchange] = exchangeName;
+        RabbitMqProperties.DeadLetterExchange.Set(builder.ConsumerSettings, exchangeName);
 
         if (exchangeType != null)
         {
-            builder.ConsumerSettings.Properties[RabbitMqProperties.DeadLetterExchangeType] = RabbitMqProducerBuilderExtensions.MapExchangeType(exchangeType.Value);
+            RabbitMqProperties.DeadLetterExchangeType.Set(builder.ConsumerSettings, exchangeType);
         }
 
         if (durable != null)
         {
-            builder.ConsumerSettings.Properties[RabbitMqProperties.DeadLetterExchangeDurable] = durable.Value;
+            RabbitMqProperties.DeadLetterExchangeDurable.Set(builder.ConsumerSettings, durable.Value);
         }
 
         if (autoDelete != null)
         {
-            builder.ConsumerSettings.Properties[RabbitMqProperties.DeadLetterExchangeAutoDelete] = autoDelete.Value;
+            RabbitMqProperties.DeadLetterExchangeAutoDelete.Set(builder.ConsumerSettings, autoDelete.Value);
         }
 
         if (routingKey != null)
         {
-            builder.ConsumerSettings.Properties[RabbitMqProperties.DeadLetterExchangeRoutingKey] = routingKey;
+            RabbitMqProperties.DeadLetterExchangeRoutingKey.Set(builder.ConsumerSettings, routingKey);
         }
 
         return builder;
@@ -115,7 +115,7 @@ public static class RabbitMqConsumerBuilderExtensions
     public static TConsumerBuilder AcknowledgementMode<TConsumerBuilder>(this TConsumerBuilder builder, RabbitMqMessageAcknowledgementMode mode)
        where TConsumerBuilder : AbstractConsumerBuilder
     {
-        builder.ConsumerSettings.Properties[RabbitMqProperties.MessageAcknowledgementMode] = mode;
+        RabbitMqProperties.MessageAcknowledgementMode.Set(builder.ConsumerSettings, mode);
         return builder;
     }
 }

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqConsumerContextExtensions.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqConsumerContextExtensions.cs
@@ -8,24 +8,16 @@ public static class RabbitMqConsumerContextExtensions
 
     public static BasicDeliverEventArgs GetTransportMessage(this IConsumerContext context)
     {
-#if NETSTANDARD2_0
         if (context is null) throw new ArgumentNullException(nameof(context));
-#else
-        ArgumentNullException.ThrowIfNull(context);
-#endif
 
-        return context.GetPropertyOrDefault<BasicDeliverEventArgs>(RabbitMqProperties.Message);
+        return context.GetPropertyOrDefault<BasicDeliverEventArgs>(RabbitMqProperties.Message.Key);
     }
 
     static internal void SetTransportMessage(this IConsumerContext context, BasicDeliverEventArgs message)
     {
-#if NETSTANDARD2_0
         if (context is null) throw new ArgumentNullException(nameof(context));
-#else
-        ArgumentNullException.ThrowIfNull(context);
-#endif
 
-        context.Properties[RabbitMqProperties.Message] = message;
+        context.Properties[RabbitMqProperties.Message.Key] = message;
     }
 
     static internal void SetConfirmAction(this IConsumerContext consumerContext, RabbitMqMessageConfirmAction messageConfirmAction)

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqMessageBusSettingsExtensions.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqMessageBusSettingsExtensions.cs
@@ -9,15 +9,10 @@ public static class RabbitMqMessageBusSettingsExtensions
     /// <param name="action">Action to be executed, the first param is the RabbitMQ <see cref="IModel"/> from the underlying client, and second parameter represents the SMB exchange, queue and binding setup</param>
     public static RabbitMqMessageBusSettings UseTopologyInitializer(this RabbitMqMessageBusSettings settings, RabbitMqTopologyInitializer action)
     {
-#if NETSTANDARD2_0
         if (settings is null) throw new ArgumentNullException(nameof(settings));
         if (action is null) throw new ArgumentNullException(nameof(action));
-#else
-        ArgumentNullException.ThrowIfNull(settings);
-        ArgumentNullException.ThrowIfNull(action);
-#endif
 
-        settings.Properties[RabbitMqProperties.TopologyInitializer] = action;
+        RabbitMqProperties.TopologyInitializer.Set(settings, action);
         return settings;
     }
 
@@ -32,11 +27,11 @@ public static class RabbitMqMessageBusSettingsExtensions
     {
         if (durable != null)
         {
-            settings.Properties[RabbitMqProperties.ExchangeDurable] = durable.Value;
+            RabbitMqProperties.ExchangeDurable.Set(settings, durable.Value);
         }
         if (autoDelete != null)
         {
-            settings.Properties[RabbitMqProperties.ExchangeAutoDelete] = autoDelete.Value;
+            RabbitMqProperties.ExchangeAutoDelete.Set(settings, autoDelete.Value);
         }
         return settings;
     }
@@ -45,28 +40,28 @@ public static class RabbitMqMessageBusSettingsExtensions
     /// Sets the default settings for dead letter exchanges on the bus level. This default will be taken unless it is overridden at the relevant producer level.
     /// </summary>
     /// <param name="settings"></param>
-    /// <param name="exchangeType"></param>
+    /// <param name="exchangeType">See <see cref="ExchangeType"/></param>
     /// <param name="durable"></param>
     /// <param name="autoDelete"></param>
     /// <param name="routingKey"></param>
     /// <returns></returns>
-    public static RabbitMqMessageBusSettings UseDeadLetterExchangeDefaults(this RabbitMqMessageBusSettings settings, ExchangeType? exchangeType = null, bool? durable = null, bool? autoDelete = null, string routingKey = null)
+    public static RabbitMqMessageBusSettings UseDeadLetterExchangeDefaults(this RabbitMqMessageBusSettings settings, string exchangeType = null, bool? durable = null, bool? autoDelete = null, string routingKey = null)
     {
         if (exchangeType != null)
         {
-            settings.Properties[RabbitMqProperties.DeadLetterExchangeType] = RabbitMqProducerBuilderExtensions.MapExchangeType(exchangeType.Value);
+            RabbitMqProperties.DeadLetterExchangeType.Set(settings, exchangeType);
         }
         if (durable != null)
         {
-            settings.Properties[RabbitMqProperties.DeadLetterExchangeDurable] = durable.Value;
+            RabbitMqProperties.DeadLetterExchangeDurable.Set(settings, durable.Value);
         }
         if (autoDelete != null)
         {
-            settings.Properties[RabbitMqProperties.DeadLetterExchangeAutoDelete] = autoDelete.Value;
+            RabbitMqProperties.DeadLetterExchangeAutoDelete.Set(settings, autoDelete.Value);
         }
         if (routingKey != null)
         {
-            settings.Properties[RabbitMqProperties.DeadLetterExchangeRoutingKey] = routingKey;
+            RabbitMqProperties.DeadLetterExchangeRoutingKey.Set(settings, routingKey);
         }
         return settings;
     }
@@ -80,19 +75,15 @@ public static class RabbitMqMessageBusSettingsExtensions
     /// <returns></returns>
     public static RabbitMqMessageBusSettings UseQueueDefaults(this RabbitMqMessageBusSettings settings, bool? durable = null, bool? autoDelete = null)
     {
-#if NETSTANDARD2_0
         if (settings is null) throw new ArgumentNullException(nameof(settings));
-#else
-        ArgumentNullException.ThrowIfNull(settings);
-#endif
 
         if (durable != null)
         {
-            settings.Properties[RabbitMqProperties.QueueDurable] = durable.Value;
+            RabbitMqProperties.QueueDurable.Set(settings, durable.Value);
         }
         if (autoDelete != null)
         {
-            settings.Properties[RabbitMqProperties.QueueAutoDelete] = autoDelete.Value;
+            RabbitMqProperties.QueueAutoDelete.Set(settings, autoDelete.Value);
         }
         return settings;
     }
@@ -105,15 +96,10 @@ public static class RabbitMqMessageBusSettingsExtensions
     /// <returns></returns>
     public static RabbitMqMessageBusSettings UseMessagePropertiesModifier(this RabbitMqMessageBusSettings settings, RabbitMqMessagePropertiesModifier<object> messagePropertiesModifier)
     {
-#if NETSTANDARD2_0
         if (settings is null) throw new ArgumentNullException(nameof(settings));
         if (messagePropertiesModifier is null) throw new ArgumentNullException(nameof(messagePropertiesModifier));
-#else
-        ArgumentNullException.ThrowIfNull(settings);
-        ArgumentNullException.ThrowIfNull(messagePropertiesModifier);
-#endif
 
-        settings.Properties[RabbitMqProperties.MessagePropertiesModifier] = messagePropertiesModifier;
+        RabbitMqProperties.MessagePropertiesModifier.Set(settings, messagePropertiesModifier);
         return settings;
     }
 
@@ -125,15 +111,10 @@ public static class RabbitMqMessageBusSettingsExtensions
     /// <returns></returns>
     public static RabbitMqMessageBusSettings UseRoutingKeyProvider(this RabbitMqMessageBusSettings settings, RabbitMqMessageRoutingKeyProvider<object> routingKeyProvider)
     {
-#if NETSTANDARD2_0
         if (settings is null) throw new ArgumentNullException(nameof(settings));
         if (routingKeyProvider is null) throw new ArgumentNullException(nameof(routingKeyProvider));
-#else
-        ArgumentNullException.ThrowIfNull(settings);
-        ArgumentNullException.ThrowIfNull(routingKeyProvider);
-#endif
 
-        settings.Properties[RabbitMqProperties.MessageRoutingKeyProvider] = routingKeyProvider;
+        RabbitMqProperties.MessageRoutingKeyProvider.Set(settings, routingKeyProvider);
         return settings;
     }
 
@@ -145,13 +126,9 @@ public static class RabbitMqMessageBusSettingsExtensions
     /// <returns></returns>
     public static RabbitMqMessageBusSettings AcknowledgementMode(this RabbitMqMessageBusSettings settings, RabbitMqMessageAcknowledgementMode mode)
     {
-#if NETSTANDARD2_0
         if (settings is null) throw new ArgumentNullException(nameof(settings));
-#else
-        ArgumentNullException.ThrowIfNull(settings);
-#endif
 
-        settings.Properties[RabbitMqProperties.MessageAcknowledgementMode] = mode;
+        RabbitMqProperties.MessageAcknowledgementMode.Set(settings, mode);
         return settings;
     }
 }

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqProperties.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqProperties.cs
@@ -2,33 +2,33 @@
 
 static internal class RabbitMqProperties
 {
-    public static readonly string ExchangeType = $"RabbitMQ_{nameof(ExchangeType)}";
-    public static readonly string ExchangeArguments = $"RabbitMQ_{nameof(ExchangeArguments)}";
-    public static readonly string ExchangeDurable = $"RabbitMQ_{nameof(ExchangeDurable)}";
-    public static readonly string ExchangeAutoDelete = $"RabbitMQ_{nameof(ExchangeAutoDelete)}";
+    public static readonly ProviderExtensionProperty<string> ExchangeType = new($"RabbitMQ_{nameof(ExchangeType)}");
+    public static readonly ProviderExtensionProperty<IDictionary<string, object>> ExchangeArguments = new($"RabbitMQ_{nameof(ExchangeArguments)}");
+    public static readonly ProviderExtensionProperty<bool> ExchangeDurable = new($"RabbitMQ_{nameof(ExchangeDurable)}");
+    public static readonly ProviderExtensionProperty<bool> ExchangeAutoDelete = new($"RabbitMQ_{nameof(ExchangeAutoDelete)}");
 
-    public static readonly string QueueName = $"RabbitMQ_{nameof(QueueName)}";
-    public static readonly string QueueDurable = $"RabbitMQ_{nameof(QueueDurable)}";
-    public static readonly string QueueAutoDelete = $"RabbitMQ_{nameof(QueueAutoDelete)}";
-    public static readonly string QueueExclusive = $"RabbitMQ_{nameof(QueueExclusive)}";
-    public static readonly string QueueArguments = $"RabbitMQ_{nameof(QueueArguments)}";
+    public static readonly ProviderExtensionProperty<string> QueueName = new($"RabbitMQ_{nameof(QueueName)}");
+    public static readonly ProviderExtensionProperty<bool> QueueDurable = new($"RabbitMQ_{nameof(QueueDurable)}");
+    public static readonly ProviderExtensionProperty<bool> QueueAutoDelete = new($"RabbitMQ_{nameof(QueueAutoDelete)}");
+    public static readonly ProviderExtensionProperty<bool> QueueExclusive = new($"RabbitMQ_{nameof(QueueExclusive)}");
+    public static readonly ProviderExtensionProperty<IDictionary<string, object>> QueueArguments = new($"RabbitMQ_{nameof(QueueArguments)}");
 
-    public static readonly string DeadLetterExchange = $"RabbitMQ_{nameof(DeadLetterExchange)}";
-    public static readonly string DeadLetterExchangeType = $"RabbitMQ_{nameof(DeadLetterExchangeType)}";
-    public static readonly string DeadLetterExchangeDurable = $"RabbitMQ_{nameof(DeadLetterExchangeDurable)}";
-    public static readonly string DeadLetterExchangeAutoDelete = $"RabbitMQ_{nameof(DeadLetterExchangeAutoDelete)}";
-    public static readonly string DeadLetterExchangeRoutingKey = $"RabbitMQ_{nameof(DeadLetterExchangeRoutingKey)}";
+    public static readonly ProviderExtensionProperty<string> DeadLetterExchange = new($"RabbitMQ_{nameof(DeadLetterExchange)}");
+    public static readonly ProviderExtensionProperty<string> DeadLetterExchangeType = new($"RabbitMQ_{nameof(DeadLetterExchangeType)}");
+    public static readonly ProviderExtensionProperty<bool> DeadLetterExchangeDurable = new($"RabbitMQ_{nameof(DeadLetterExchangeDurable)}");
+    public static readonly ProviderExtensionProperty<bool> DeadLetterExchangeAutoDelete = new($"RabbitMQ_{nameof(DeadLetterExchangeAutoDelete)}");
+    public static readonly ProviderExtensionProperty<string> DeadLetterExchangeRoutingKey = new($"RabbitMQ_{nameof(DeadLetterExchangeRoutingKey)}");
 
-    public static readonly string BindingRoutingKey = $"RabbitMQ_{nameof(BindingRoutingKey)}";
+    public static readonly ProviderExtensionProperty<string> BindingRoutingKey = new($"RabbitMQ_{nameof(BindingRoutingKey)}");
 
-    public static readonly string MessageRoutingKeyProvider = $"RabbitMQ_{nameof(MessageRoutingKeyProvider)}";
-    public static readonly string MessagePropertiesModifier = $"RabbitMQ_{nameof(MessagePropertiesModifier)}";
+    public static readonly ProviderExtensionProperty<RabbitMqMessageRoutingKeyProvider<object>> MessageRoutingKeyProvider = new($"RabbitMQ_{nameof(MessageRoutingKeyProvider)}");
+    public static readonly ProviderExtensionProperty<RabbitMqMessagePropertiesModifier<object>> MessagePropertiesModifier = new($"RabbitMQ_{nameof(MessagePropertiesModifier)}");
 
-    public static readonly string TopologyInitializer = $"RabbitMQ_{nameof(TopologyInitializer)}";
+    public static readonly ProviderExtensionProperty<RabbitMqTopologyInitializer> TopologyInitializer = new($"RabbitMQ_{nameof(TopologyInitializer)}");
 
-    public static readonly string Message = $"RabbitMQ_{nameof(Message)}";
+    public static readonly ProviderExtensionProperty<BasicDeliverEventArgs> Message = new($"RabbitMQ_{nameof(Message)}");
 
-    public static readonly string ProviderSettings = $"RabbitMQ_{nameof(ProviderSettings)}";
+    public static readonly ProviderExtensionProperty<RabbitMqMessageBusSettings> ProviderSettings = new($"RabbitMQ_{nameof(ProviderSettings)}");
 
-    public static readonly string MessageAcknowledgementMode = $"RabbitMQ_{nameof(MessageAcknowledgementMode)}";
+    public static readonly ProviderExtensionProperty<RabbitMqMessageAcknowledgementMode?> MessageAcknowledgementMode = new($"RabbitMQ_{nameof(MessageAcknowledgementMode)}");
 }

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqRequestResponseBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqRequestResponseBuilderExtensions.cs
@@ -8,12 +8,12 @@ public static class RabbitMqRequestResponseBuilderExtensions
     /// <remarks>Setting the name is equivalent to using <see cref="RequestResponseBuilder.DefaultPath(string)"/>.</remarks>
     /// <param name="builder"></param>
     /// <param name="exchangeName"></param>
-    /// <param name="exchangeType"></param>
+    /// <param name="exchangeType">See <see cref="ExchangeType"/></param>
     /// <param name="durable"></param>
     /// <param name="autoDelete"></param>
     /// <param name="arguments"></param>
     /// <returns></returns>
-    public static RequestResponseBuilder ReplyToExchange(this RequestResponseBuilder builder, string exchangeName, ExchangeType? exchangeType = null, bool? durable = null, bool? autoDelete = null, IDictionary<string, object> arguments = null)
+    public static RequestResponseBuilder ReplyToExchange(this RequestResponseBuilder builder, string exchangeName, string exchangeType = null, bool? durable = null, bool? autoDelete = null, IDictionary<string, object> arguments = null)
     {
         if (string.IsNullOrEmpty(exchangeName)) throw new ArgumentNullException(nameof(exchangeName));
 
@@ -30,8 +30,7 @@ public static class RabbitMqRequestResponseBuilderExtensions
     /// <returns></returns>
     public static RequestResponseBuilder ExchangeBinding(this RequestResponseBuilder builder, string routingKey = "")
     {
-        builder.Settings.Properties[RabbitMqProperties.BindingRoutingKey] = routingKey;
-
+        RabbitMqProperties.BindingRoutingKey.Set(builder.Settings, routingKey);
         return builder;
     }
 }

--- a/src/SlimMessageBus.Host.RabbitMQ/Consumers/RabbitMqConsumer.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Consumers/RabbitMqConsumer.cs
@@ -33,7 +33,7 @@ public class RabbitMqConsumer : AbstractRabbitMqConsumer, IRabbitMqConsumer
                queueName,
                headerValueConverter)
     {
-        _acknowledgementMode = consumers.Select(x => x.GetOrDefault<RabbitMqMessageAcknowledgementMode?>(RabbitMqProperties.MessageAcknowledgementMode, messageBus.Settings)).FirstOrDefault(x => x != null)
+        _acknowledgementMode = consumers.Select(x => x.GetOrDefault(RabbitMqProperties.MessageAcknowledgementMode, messageBus.Settings)).FirstOrDefault(x => x != null)
             ?? RabbitMqMessageAcknowledgementMode.ConfirmAfterMessageProcessingWhenNoManualConfirmMade; // be default choose the safer acknowledgement mode
 
         IMessageProcessor<BasicDeliverEventArgs> CreateMessageProcessor(IEnumerable<ConsumerSettings> consumers)

--- a/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBus.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBus.cs
@@ -112,7 +112,7 @@ public class RabbitMqMessageBus : MessageBusBase<RabbitMqMessageBusSettings>, IR
 
                     var topologyService = new RabbitMqTopologyService(LoggerFactory, _channel, Settings, ProviderSettings);
 
-                    var customAction = ProviderSettings.GetOrDefault<RabbitMqTopologyInitializer>(RabbitMqProperties.TopologyInitializer);
+                    var customAction = ProviderSettings.GetOrDefault(RabbitMqProperties.TopologyInitializer);
                     if (customAction != null)
                     {
                         // Allow the user to specify its own initializer

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/Config/RabbitMqConsumerBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/Config/RabbitMqConsumerBuilderExtensionsTests.cs
@@ -21,7 +21,7 @@ public class RabbitMqConsumerBuilderExtensionsTests
         _consumerBuilder.AcknowledgementMode(mode);
 
         // assert
-        var modeReturned = _consumerBuilder.Settings.GetOrDefault<RabbitMqMessageAcknowledgementMode>(RabbitMqProperties.MessageAcknowledgementMode);
+        var modeReturned = _consumerBuilder.ConsumerSettings.GetOrDefault(RabbitMqProperties.MessageAcknowledgementMode);
         modeReturned.Should().Be(mode);
     }
 }

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/Config/RabbitMqMessageBusSettingsExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/Config/RabbitMqMessageBusSettingsExtensionsTests.cs
@@ -15,7 +15,7 @@ public class RabbitMqMessageBusSettingsExtensionsTests
         _settings.AcknowledgementMode(mode);
 
         // assert
-        var modeReturned = _settings.GetOrDefault<RabbitMqMessageAcknowledgementMode>(RabbitMqProperties.MessageAcknowledgementMode);
+        var modeReturned = _settings.GetOrDefault(RabbitMqProperties.MessageAcknowledgementMode);
         modeReturned.Should().Be(mode);
     }
 
@@ -29,7 +29,7 @@ public class RabbitMqMessageBusSettingsExtensionsTests
         _settings.UseRoutingKeyProvider(routingKeyProviderMock.Object);
 
         // assert
-        var routingKeyProviderReturned = _settings.GetOrDefault<RabbitMqMessageRoutingKeyProvider<object>>(RabbitMqProperties.MessageRoutingKeyProvider);
+        var routingKeyProviderReturned = _settings.GetOrDefault(RabbitMqProperties.MessageRoutingKeyProvider);
         routingKeyProviderReturned.Should().BeSameAs(routingKeyProviderMock.Object);
     }
 }


### PR DESCRIPTION
- Convert `ExchangeType` from enum to a string to allow to pass custom exchange types
- Introduce the `x-delayed-message` static value to account for delayed message Rabbit plugin as per #396 