### PR TITLE
Allow Access to Full Message During Deserialization

### DIFF
--- a/src/Host.Plugin.Properties.xml
+++ b/src/Host.Plugin.Properties.xml
@@ -4,7 +4,7 @@
   <Import Project="Common.NuGet.Properties.xml" />
 
   <PropertyGroup>
-    <Version>3.3.0-rc201</Version>
+    <Version>3.3.0-rc202</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.AmazonSQS/Consumer/SqsBaseConsumer.cs
+++ b/src/SlimMessageBus.Host.AmazonSQS/Consumer/SqsBaseConsumer.cs
@@ -151,12 +151,14 @@ abstract internal class SqsBaseConsumer : AbstractConsumer
         }
     }
 
+    private static readonly IReadOnlyDictionary<string, object> EmptyHeaders = new Dictionary<string, object>();
+
     private void GetPayloadAndHeadersFromMessage(Message message, out string messagePayload, out Dictionary<string, object> messageHeaders)
     {
         if (_isSubscribedToTopic)
         {
             // Note: Messages ariving from SNS topics are wrapped in an envelope like SnsEnvelope type. We need to get the actual message and headers from it.
-            var snsEnvelope = (SnsEnvelope)MessageSerializer.Deserialize(typeof(SnsEnvelope), message.Body);
+            var snsEnvelope = (SnsEnvelope)MessageSerializer.Deserialize(typeof(SnsEnvelope), EmptyHeaders, message.Body, message);
 
             messagePayload = snsEnvelope.Message ?? throw new ConsumerMessageBusException("Message of the SNS Envelope was null");
             messageHeaders = (snsEnvelope.MessageAttributes ?? throw new ConsumerMessageBusException("Message of the SNS Envelope was null"))

--- a/src/SlimMessageBus.Host.AmazonSQS/GlobalUsings.cs
+++ b/src/SlimMessageBus.Host.AmazonSQS/GlobalUsings.cs
@@ -11,4 +11,3 @@ global using Microsoft.Extensions.Logging;
 
 global using SlimMessageBus.Host.Consumer.ErrorHandling;
 global using SlimMessageBus.Host.Serialization;
-

--- a/src/SlimMessageBus.Host.AzureEventHub/EventHubMessageBus.cs
+++ b/src/SlimMessageBus.Host.AzureEventHub/EventHubMessageBus.cs
@@ -55,24 +55,25 @@ public class EventHubMessageBus : MessageBusBase<EventHubMessageBusSettings>
     {
         await base.CreateConsumers();
 
+        MessageProvider<EventData> GetMessageProvider(string path)
+            => SerializerProvider.GetSerializer(path).GetMessageProvider<byte[], EventData>(t => t.Body.ToArray());
+
         foreach (var (groupPath, consumerSettings) in Settings.Consumers.GroupBy(x => new GroupPath(path: x.Path, group: x.GetGroup())).ToDictionary(x => x.Key, x => x.ToList()))
         {
-            var messageSerializer = SerializerProvider.GetSerializer(groupPath.Path);
-            object MessageProvider(Type messageType, EventData transportMessage) => messageSerializer.Deserialize(messageType, transportMessage.Body.ToArray());
+            var messageProvider = GetMessageProvider(groupPath.Path);
 
             _logger.LogInformation("Creating consumer for Path: {Path}, Group: {Group}", groupPath.Path, groupPath.Group);
-            AddConsumer(new EhGroupConsumer(consumerSettings, this, groupPath, groupPathPartition => new EhPartitionConsumerForConsumers(this, consumerSettings, groupPathPartition, MessageProvider)));
+            AddConsumer(new EhGroupConsumer(consumerSettings, this, groupPath, groupPathPartition => new EhPartitionConsumerForConsumers(this, consumerSettings, groupPathPartition, messageProvider)));
         }
 
         if (Settings.RequestResponse != null)
         {
             var groupPath = new GroupPath(Settings.RequestResponse.Path, Settings.RequestResponse.GetGroup());
 
-            var messageSerializer = SerializerProvider.GetSerializer(groupPath.Path);
-            object MessageProvider(Type messageType, EventData transportMessage) => messageSerializer.Deserialize(messageType, transportMessage.Body.ToArray());
+            var messageProvider = GetMessageProvider(groupPath.Path);
 
             _logger.LogInformation("Creating response consumer for Path: {Path}, Group: {Group}", groupPath.Path, groupPath.Group);
-            AddConsumer(new EhGroupConsumer([Settings.RequestResponse], this, groupPath, groupPathPartition => new EhPartitionConsumerForResponses(this, Settings.RequestResponse, groupPathPartition, MessageProvider, PendingRequestStore, TimeProvider)));
+            AddConsumer(new EhGroupConsumer([Settings.RequestResponse], this, groupPath, groupPathPartition => new EhPartitionConsumerForResponses(this, Settings.RequestResponse, groupPathPartition, messageProvider, PendingRequestStore, TimeProvider)));
         }
     }
 
@@ -114,13 +115,12 @@ public class EventHubMessageBus : MessageBusBase<EventHubMessageBusSettings>
     {
         OnProduceToTransport(message, messageType, path, messageHeaders);
 
-        var messagePayload = message != null
-            ? SerializerProvider.GetSerializer(path).Serialize(messageType, message)
-            : null;
+        var transportMessage = new EventData();
 
-        var transportMessage = message != null
-            ? new EventData(messagePayload)
-            : new EventData();
+        if (message != null)
+        {
+            transportMessage.EventBody = new BinaryData(SerializerProvider.GetSerializer(path).Serialize(messageType, messageHeaders, message, transportMessage));
+        }
 
         if (messageHeaders != null)
         {

--- a/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
+++ b/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
@@ -6,7 +6,7 @@
     <Description>Core configuration interfaces of SlimMessageBus</Description>
     <PackageTags>SlimMessageBus</PackageTags>
     <RootNamespace>SlimMessageBus.Host</RootNamespace>
-    <Version>3.3.0-rc201</Version>
+    <Version>3.3.0-rc202</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Kafka/Consumer/KafkaExtensions.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/KafkaExtensions.cs
@@ -16,7 +16,7 @@ internal static class KafkaExtensions
         var headers = new Dictionary<string, object>();
         foreach (var header in consumeResult.Message.Headers)
         {
-            var value = headerSerializer.Deserialize(typeof(object), header.GetValueBytes());
+            var value = headerSerializer.Deserialize(typeof(object), null, header.GetValueBytes(), null);
             headers[header.Key] = value;
         }
 

--- a/src/SlimMessageBus.Host.Kafka/Consumer/KafkaPartitionConsumerForConsumers.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/KafkaPartitionConsumerForConsumers.cs
@@ -8,7 +8,14 @@ using ConsumeResult = ConsumeResult<Ignore, byte[]>;
 /// </summary>
 public class KafkaPartitionConsumerForConsumers : KafkaPartitionConsumer
 {
-    public KafkaPartitionConsumerForConsumers(ILoggerFactory loggerFactory, ConsumerSettings[] consumerSettings, string group, TopicPartition topicPartition, IKafkaCommitController commitController, IMessageSerializer headerSerializer, MessageBusBase messageBus)
+    public KafkaPartitionConsumerForConsumers(ILoggerFactory loggerFactory,
+                                              ConsumerSettings[] consumerSettings,
+                                              string group,
+                                              TopicPartition topicPartition,
+                                              IKafkaCommitController commitController,
+                                              IMessageSerializer headerSerializer,
+                                              MessageProvider<ConsumeResult> messageProvider,
+                                              MessageBusBase messageBus)
         : base(
             loggerFactory,
             consumerSettings,
@@ -21,7 +28,7 @@ public class KafkaPartitionConsumerForConsumers : KafkaPartitionConsumer
                 messageBus,
                 path: topicPartition.Topic,
                 responseProducer: messageBus,
-                messageProvider: (messageType, transportMessage) => messageBus.SerializerProvider.GetSerializer(topicPartition.Topic).Deserialize(messageType, transportMessage.Message.Value),
+                messageProvider: messageProvider,
                 consumerContextInitializer: (m, ctx) => ctx.SetTransportMessage(m),
                 consumerErrorHandlerOpenGenericType: typeof(IKafkaConsumerErrorHandler<>)))
     {

--- a/src/SlimMessageBus.Host.Kafka/DefaultKafkaHeaderSerializer.cs
+++ b/src/SlimMessageBus.Host.Kafka/DefaultKafkaHeaderSerializer.cs
@@ -1,5 +1,6 @@
 ﻿namespace SlimMessageBus.Host.Kafka;
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 
@@ -24,14 +25,14 @@ public class DefaultKafkaHeaderSerializer : IMessageSerializer, IMessageSerializ
 
     #region Implementation of IMessageSerializer
 
-    public byte[] Serialize(Type t, object message)
+    public byte[] Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage)
     {
         if (message == null) return null;
         var payload = _encoding.GetBytes(Convert.ToString(message, CultureInfo.InvariantCulture));
         return payload;
     }
 
-    public object Deserialize(Type t, byte[] payload)
+    public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage)
     {
         if (payload == null) return null;
 

--- a/src/SlimMessageBus.Host.Memory/NullMessageSerializerProvider.cs
+++ b/src/SlimMessageBus.Host.Memory/NullMessageSerializerProvider.cs
@@ -2,9 +2,9 @@
 
 internal class NullMessageSerializerProvider : IMessageSerializer, IMessageSerializerProvider
 {
-    public object Deserialize(Type t, byte[] payload) => null;
+    public byte[] Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage) => [];
 
-    public byte[] Serialize(Type t, object message) => null;
+    public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage) => null;
 
     public IMessageSerializer GetSerializer(string path) => this;
 }

--- a/src/SlimMessageBus.Host.Outbox.PostgreSql/Repositories/PostgreSqlOutboxMessageRepository.cs
+++ b/src/SlimMessageBus.Host.Outbox.PostgreSql/Repositories/PostgreSqlOutboxMessageRepository.cs
@@ -174,7 +174,7 @@ public class PostgreSqlOutboxMessageRepository : IPostgreSqlMessageOutboxReposit
                 MessagePayload = await reader.GetFieldValueAsync<byte[]>(payloadOrdinal, cancellationToken),
                 Headers = headers == null
                     ? null
-                    : JsonSerializer.Deserialize<IDictionary<string, object>>(headers, _jsonOptions),
+                    : JsonSerializer.Deserialize<Dictionary<string, object>>(headers, _jsonOptions),
                 Path = await reader.IsDBNullAsync(pathOrdinal, cancellationToken)
                     ? null
                     : reader.GetString(pathOrdinal)
@@ -283,7 +283,7 @@ public class PostgreSqlOutboxMessageRepository : IPostgreSqlMessageOutboxReposit
                 MessagePayload = await reader.GetFieldValueAsync<byte[]>(payloadOrdinal, cancellationToken),
                 Headers = headers == null
                     ? null
-                    : JsonSerializer.Deserialize<IDictionary<string, object>>(headers, _jsonOptions),
+                    : JsonSerializer.Deserialize<Dictionary<string, object>>(headers, _jsonOptions),
                 Path = await reader.IsDBNullAsync(pathOrdinal, cancellationToken)
                     ? null
                     : reader.GetString(pathOrdinal),

--- a/src/SlimMessageBus.Host.Outbox.Sql/SqlOutboxMessageRepository.cs
+++ b/src/SlimMessageBus.Host.Outbox.Sql/SqlOutboxMessageRepository.cs
@@ -126,7 +126,7 @@ public class SqlOutboxMessageRepository : CommonSqlRepository, ISqlMessageOutbox
                 MessagePayload = reader.GetSqlBinary(payloadOrdinal).Value,
                 Headers = headers == null
                     ? null
-                    : JsonSerializer.Deserialize<IDictionary<string, object>>(headers, _jsonOptions),
+                    : JsonSerializer.Deserialize<Dictionary<string, object>>(headers, _jsonOptions),
                 Path = reader.IsDBNull(pathOrdinal)
                     ? null
                     : reader.GetString(pathOrdinal)
@@ -279,7 +279,7 @@ public class SqlOutboxMessageRepository : CommonSqlRepository, ISqlMessageOutbox
                 MessagePayload = reader.GetSqlBinary(payloadOrdinal).Value,
                 Headers = headers == null
                     ? null
-                    : JsonSerializer.Deserialize<IDictionary<string, object>>(headers, _jsonOptions),
+                    : JsonSerializer.Deserialize<Dictionary<string, object>>(headers, _jsonOptions),
                 Path = reader.IsDBNull(pathOrdinal)
                     ? null
                     : reader.GetString(pathOrdinal),

--- a/src/SlimMessageBus.Host.Outbox/Interceptors/OutboxForwardingPublishInterceptor.cs
+++ b/src/SlimMessageBus.Host.Outbox/Interceptors/OutboxForwardingPublishInterceptor.cs
@@ -52,7 +52,7 @@ public sealed class OutboxForwardingPublishInterceptor<T>(
 
         var messageType = message.GetType();
         // Take the proper serializer (meant for the bus)
-        var messagePayload = busMaster.SerializerProvider?.GetSerializer(context.Path).Serialize(messageType, message)
+        var messagePayload = busMaster.SerializerProvider?.GetSerializer(context.Path).Serialize(messageType, context.Headers, message, null)
                 ?? throw new PublishMessageBusException($"The {busMaster.Name} bus has no configured serializer, so it cannot be used with the outbox plugin");
 
         var outboxMessage = await outboxMessageFactory.Create(
@@ -69,4 +69,5 @@ public sealed class OutboxForwardingPublishInterceptor<T>(
         // A message was sent, notify outbox service to poll on dispose (post transaction)
         _notifyOutbox = true;
     }
+
 }

--- a/src/SlimMessageBus.Host.Outbox/Services/OutboxSendingTask.cs
+++ b/src/SlimMessageBus.Host.Outbox/Services/OutboxSendingTask.cs
@@ -281,9 +281,9 @@ internal class OutboxSendingTask<TOutboxMessage>(
                             _logger.LogError("Outbox message with Id {Id} - the MessageType {MessageType} is not recognised. The type might have been renamed or moved namespaces.", outboxMessage, outboxMessage.MessageType);
                             return null;
                         }
-
-                        var message = messageSerializer.Deserialize(messageType, outboxMessage.MessagePayload);
-                        return new OutboxBulkMessage(outboxMessage, message, messageType, outboxMessage.Headers ?? new Dictionary<string, object>());
+                        var messageHeaders = outboxMessage.Headers ?? new Dictionary<string, object>();
+                        var message = messageSerializer.Deserialize(messageType, messageHeaders.AsReadOnly(), outboxMessage.MessagePayload, null);
+                        return new OutboxBulkMessage(outboxMessage, message, messageType, messageHeaders);
                     })
                     .Where(x => x != null)
                     .Batch(bulkProducer.MaxMessagesPerTransaction ?? defaultBatchSize);

--- a/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBus.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBus.cs
@@ -38,17 +38,17 @@ public class RabbitMqMessageBus : MessageBusBase<RabbitMqMessageBusSettings>, IR
     {
         await base.CreateConsumers();
 
+        MessageProvider<BasicDeliverEventArgs> GetMessageProvider(string path)
+            => SerializerProvider.GetSerializer(path).GetMessageProvider<byte[], BasicDeliverEventArgs>(t => t.Body.ToArray());
+
         foreach (var (queueName, consumers) in Settings.Consumers.GroupBy(x => x.GetQueueName()).ToDictionary(x => x.Key, x => x.ToList()))
         {
-            var messageSerializer = SerializerProvider.GetSerializer(queueName);
-            object MessageProvider(Type messageType, BasicDeliverEventArgs transportMessage) => messageSerializer.Deserialize(messageType, transportMessage.Body.ToArray());
-
             AddConsumer(new RabbitMqConsumer(LoggerFactory,
                 channel: this,
                 queueName: queueName,
                 consumers,
                 messageBus: this,
-                MessageProvider,
+                messageProvider: GetMessageProvider(queueName),
                 ProviderSettings.HeaderValueConverter));
         }
 
@@ -56,15 +56,12 @@ public class RabbitMqMessageBus : MessageBusBase<RabbitMqMessageBusSettings>, IR
         {
             var queueName = Settings.RequestResponse.GetQueueName();
 
-            var messageSerializer = SerializerProvider.GetSerializer(queueName);
-            object MessageProvider(Type messageType, BasicDeliverEventArgs transportMessage) => messageSerializer.Deserialize(messageType, transportMessage.Body.ToArray());
-
             AddConsumer(new RabbitMqResponseConsumer(LoggerFactory,
                 interceptors: Settings.ServiceProvider.GetServices<IAbstractConsumerInterceptor>(),
                 channel: this,
                 queueName: queueName,
                 Settings.RequestResponse,
-                MessageProvider,
+                messageProvider: GetMessageProvider(queueName),
                 PendingRequestStore,
                 TimeProvider,
                 ProviderSettings.HeaderValueConverter));
@@ -205,7 +202,7 @@ public class RabbitMqMessageBus : MessageBusBase<RabbitMqMessageBusSettings>, IR
     private void GetTransportMessage(object message, Type messageType, IDictionary<string, object> messageHeaders, string path, out byte[] messagePayload, out IBasicProperties messageProperties, out string routingKey)
     {
         var producer = GetProducerSettings(messageType);
-        messagePayload = SerializerProvider.GetSerializer(path).Serialize(messageType, message);
+        messagePayload = SerializerProvider.GetSerializer(path).Serialize(messageType, messageHeaders, message, null);
         messageProperties = _channel.CreateBasicProperties();
         if (messageHeaders != null)
         {

--- a/src/SlimMessageBus.Host.Redis/Consumers/RedisListCheckerConsumer.cs
+++ b/src/SlimMessageBus.Host.Redis/Consumers/RedisListCheckerConsumer.cs
@@ -75,7 +75,7 @@ public class RedisListCheckerConsumer : AbstractConsumer, IRedisConsumer
                     Logger.LogDebug("Retrieved value on queue {Queue}", queue.Name);
                     try
                     {
-                        var transportMessage = (MessageWithHeaders)_envelopeSerializer.Deserialize(typeof(MessageWithHeaders), value);
+                        var transportMessage = (MessageWithHeaders)_envelopeSerializer.Deserialize(typeof(MessageWithHeaders), null, value, null);
 
                         // for loop to avoid iterator allocation
                         for (var i = 0; i < queue.Processors.Count && !CancellationToken.IsCancellationRequested; i++)

--- a/src/SlimMessageBus.Host.Redis/Consumers/RedisTopicConsumer.cs
+++ b/src/SlimMessageBus.Host.Redis/Consumers/RedisTopicConsumer.cs
@@ -48,7 +48,7 @@ public class RedisTopicConsumer : AbstractConsumer, IRedisConsumer
         Exception exception;
         try
         {
-            var messageWithHeaders = (MessageWithHeaders)_envelopeSerializer.Deserialize(typeof(MessageWithHeaders), m.Message);
+            var messageWithHeaders = (MessageWithHeaders)_envelopeSerializer.Deserialize(typeof(MessageWithHeaders), null, m.Message, null);
 
             var r = await _messageProcessor.ProcessMessage(messageWithHeaders, messageWithHeaders.Headers, cancellationToken: CancellationToken);
             exception = r.Exception;

--- a/src/SlimMessageBus.Host.Serialization.Avro/AvroMessageSerializer.cs
+++ b/src/SlimMessageBus.Host.Serialization.Avro/AvroMessageSerializer.cs
@@ -1,5 +1,7 @@
 ﻿namespace SlimMessageBus.Host.Serialization.Avro;
 
+using System.Collections.Generic;
+
 using global::Avro;
 using global::Avro.IO;
 using global::Avro.Specific;
@@ -70,27 +72,6 @@ public class AvroMessageSerializer : IMessageSerializer, IMessageSerializerProvi
         ReadSchemaLookup = readerSchemaLookupStrategy.Lookup;
     }
 
-    public object Deserialize(Type t, byte[] payload)
-    {
-        using var ms = ReadMemoryStreamFactory(payload);
-
-        var dec = new BinaryDecoder(ms);
-
-        var message = MessageFactory(t);
-
-        var readerSchema = ReadSchemaLookup(t);
-        AssertSchemaNotNull(t, readerSchema, false);
-
-        var writerSchema = WriteSchemaLookup(t);
-        AssertSchemaNotNull(t, writerSchema, true);
-
-        _logger.LogDebug("Type {Type} writer schema: {WriterSchema}, reader schema: {ReaderSchema}", t, writerSchema, readerSchema);
-
-        var reader = new SpecificDefaultReader(writerSchema, readerSchema);
-        reader.Read(message, dec);
-        return message;
-    }
-
     private static void AssertSchemaNotNull(Type t, Schema schema, bool writerSchema)
     {
         if (schema == null)
@@ -100,19 +81,40 @@ public class AvroMessageSerializer : IMessageSerializer, IMessageSerializerProvi
         }
     }
 
-    public byte[] Serialize(Type t, object message)
+    public byte[] Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage)
     {
         using var ms = WriteMemoryStreamFactory();
         var enc = new BinaryEncoder(ms);
 
-        var writerSchema = WriteSchemaLookup(t);
-        AssertSchemaNotNull(t, writerSchema, true);
+        var writerSchema = WriteSchemaLookup(messageType);
+        AssertSchemaNotNull(messageType, writerSchema, true);
 
-        _logger.LogDebug("Type {Type} writer schema: {WriterSchema}", t, writerSchema);
+        _logger.LogDebug("Type {Type} writer schema: {WriterSchema}", messageType, writerSchema);
 
         var writer = new SpecificDefaultWriter(writerSchema); // Schema comes from pre-compiled, code-gen phase
         writer.Write(message, enc);
         return ms.ToArray();
+    }
+
+    public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage)
+    {
+        using var ms = ReadMemoryStreamFactory(payload);
+
+        var dec = new BinaryDecoder(ms);
+
+        var message = MessageFactory(messageType);
+
+        var readerSchema = ReadSchemaLookup(messageType);
+        AssertSchemaNotNull(messageType, readerSchema, false);
+
+        var writerSchema = WriteSchemaLookup(messageType);
+        AssertSchemaNotNull(messageType, writerSchema, true);
+
+        _logger.LogDebug("Type {Type} writer schema: {WriterSchema}, reader schema: {ReaderSchema}", messageType, writerSchema, readerSchema);
+
+        var reader = new SpecificDefaultReader(writerSchema, readerSchema);
+        reader.Read(message, dec);
+        return message;
     }
 
     // ToDo: Leverage to implement Avro specific feature: https://github.com/zarusz/SlimMessageBus/issues/370

--- a/src/SlimMessageBus.Host.Serialization.GoogleProtobuf/GoogleProtobufMessageSerializer.cs
+++ b/src/SlimMessageBus.Host.Serialization.GoogleProtobuf/GoogleProtobufMessageSerializer.cs
@@ -1,5 +1,6 @@
 namespace SlimMessageBus.Host.Serialization.GoogleProtobuf;
 
+using System.Collections.Generic;
 using System.Reflection;
 
 using Google.Protobuf;
@@ -15,12 +16,12 @@ public class GoogleProtobufMessageSerializer : IMessageSerializer, IMessageSeria
         _messageParserFactory = messageParserFactory ?? new MessageParserFactory();
     }
 
-    public byte[] Serialize(Type t, object message)
+    public byte[] Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage)
         => ((IMessage)message).ToByteArray();
 
-    public object Deserialize(Type t, byte[] payload)
+    public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage)
     {
-        var messageParser = _messageParserFactory.CreateMessageParser(t);
+        var messageParser = _messageParserFactory.CreateMessageParser(messageType);
         try
         {
             var message = messageParser.GetType()
@@ -35,7 +36,7 @@ public class GoogleProtobufMessageSerializer : IMessageSerializer, IMessageSeria
         }
         catch (TargetInvocationException exception)
         {
-            _logger.LogWarning(exception, "Failed to call 'ParseFrom' of type [{typename}]", t.FullName);
+            _logger.LogWarning(exception, "Failed to call 'ParseFrom' of type [{typename}]", messageType.FullName);
 
             throw exception.InnerException ?? exception;
         }

--- a/src/SlimMessageBus.Host.Serialization.Hybrid/HybridMessageSerializerProvider.cs
+++ b/src/SlimMessageBus.Host.Serialization.Hybrid/HybridMessageSerializerProvider.cs
@@ -65,16 +65,16 @@ public class HybridMessageSerializerProvider : IMessageSerializerProvider
 
     sealed class HybidMessageSerializer(HybridMessageSerializerProvider provider, string path) : IMessageSerializer
     {
-        public object Deserialize(Type t, byte[] payload)
+        public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage)
         {
-            var serializer = provider.MatchSerializer(path, t);
-            return serializer.Deserialize(t, payload);
+            var serializer = provider.MatchSerializer(path, messageType);
+            return serializer.Deserialize(messageType, headers, payload, transportMessage);
         }
 
-        public byte[] Serialize(Type t, object message)
+        public byte[] Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage)
         {
-            var serializer = provider.MatchSerializer(path, t);
-            return serializer.Serialize(t, message);
+            var serializer = provider.MatchSerializer(path, messageType);
+            return serializer.Serialize(messageType, headers, message, transportMessage);
         }
     }
 }

--- a/src/SlimMessageBus.Host.Serialization.SystemTextJson/JsonMessageSerializer.cs
+++ b/src/SlimMessageBus.Host.Serialization.SystemTextJson/JsonMessageSerializer.cs
@@ -1,5 +1,6 @@
 ﻿namespace SlimMessageBus.Host.Serialization.SystemTextJson;
 
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -32,21 +33,21 @@ public class JsonMessageSerializer : IMessageSerializer, IMessageSerializer<stri
 
     #region Implementation of IMessageSerializer
 
-    public byte[] Serialize(Type t, object message) =>
-        JsonSerializer.SerializeToUtf8Bytes(message, t, Options);
+    public byte[] Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage)
+        => JsonSerializer.SerializeToUtf8Bytes(message, messageType, Options);
 
-    public object Deserialize(Type t, byte[] payload) =>
-        JsonSerializer.Deserialize(payload, t, Options)!;
+    public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage)
+        => JsonSerializer.Deserialize(payload, messageType, Options)!;
 
     #endregion
 
     #region Implementation of IMessageSerializer<string>
 
-    string IMessageSerializer<string>.Serialize(Type t, object message)
-        => JsonSerializer.Serialize(message, t, Options);
+    string IMessageSerializer<string>.Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage)
+        => JsonSerializer.Serialize(message, messageType, Options);
 
-    object IMessageSerializer<string>.Deserialize(Type t, string payload)
-        => JsonSerializer.Deserialize(payload, t, Options)!;
+    public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, string payload, object transportMessage)
+        => JsonSerializer.Deserialize(payload, messageType, Options)!;
 
     #endregion
 

--- a/src/SlimMessageBus.Host.Serialization/IMessageSerializer.cs
+++ b/src/SlimMessageBus.Host.Serialization/IMessageSerializer.cs
@@ -13,6 +13,25 @@ public interface IMessageSerializer : IMessageSerializer<byte[]>
 /// <typeparam name="TPayload"></typeparam>
 public interface IMessageSerializer<TPayload>
 {
-    TPayload Serialize(Type t, object message);
-    object Deserialize(Type t, TPayload payload);
+    /// <summary>
+    /// Used to serialize an application message to the transport message payload.
+    /// </summary>
+    /// <param name="messageType">The produced message type</param>
+    /// <param name="headers">Message headers that are set, which will be placed into the transport message (if transport supports headers). Can be updated if the serializer needs to pass additional details message headers to the deserializer.</param>
+    /// <param name="message">The produced application message</param>
+    /// <param name="transportMessage">The underlying transport message that will be used to transport the message. For some transports it might be null when it cannot be provided before the payload is provided. Can be used to set additional transport message properties (if that transport passes the native message before payload).</param>
+    /// <returns></returns>
+    TPayload Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage);
+
+    /// <summary>
+    /// Used to deserialize an application message from the transport message payload.
+    /// </summary>
+    /// <param name="messageType">The expected consumer message type</param>
+    /// <param name="headers">Message headers that have been read from the transport message (if transport supports headers).</param>
+    /// <param name="payload">The transport message payload to be deserialized</param>
+    /// <param name="transportMessage">The underlying transport message, that is being deserialized. Can be used to understand message formatting, type or compression.</param>
+    /// <returns></returns>
+    object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, TPayload payload, object transportMessage);
 }
+
+

--- a/src/SlimMessageBus.Host.Serialization/SlimMessageBus.Host.Serialization.csproj
+++ b/src/SlimMessageBus.Host.Serialization/SlimMessageBus.Host.Serialization.csproj
@@ -3,7 +3,7 @@
   <Import Project="../Common.NuGet.Properties.xml" />
 
   <PropertyGroup>
-    <Version>3.1.0</Version>
+    <Version>3.3.0-rc202</Version>
     <Description>Core serialization interfaces of SlimMessageBus</Description>
     <PackageTags>SlimMessageBus</PackageTags>
   </PropertyGroup>

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/Delegates.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/Delegates.cs
@@ -22,14 +22,16 @@ public delegate void ConsumerContextInitializer<T>(T transportMessage, ConsumerC
 /// </summary>
 /// <typeparam name="T"></typeparam>
 /// <param name="transportMessage"></param>
+/// <param name="messageHeaders"></param>
 /// <returns></returns>
-public delegate Type MessageTypeProvider<in T>(T transportMessage);
+public delegate Type MessageTypeProvider<in T>(T transportMessage, IReadOnlyDictionary<string, object> messageHeaders);
 
 /// <summary>
 /// For a given message type and transport message return the application message.
 /// </summary>
 /// <typeparam name="T">Type of the transport message</typeparam>
 /// <param name="messageType"></param>
+/// <param name="messageHeaders"></param>
 /// <param name="transportMessage"></param>
 /// <returns></returns>
-public delegate object MessageProvider<in T>(Type messageType, T transportMessage);
+public delegate object MessageProvider<in T>(Type messageType, IReadOnlyDictionary<string, object> messageHeaders, T transportMessage);

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/IMessageSerializerExtensions.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/IMessageSerializerExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace SlimMessageBus.Host;
+
+public static class IMessageSerializerExtensions
+{
+    public static MessageProvider<TTransportMessage> GetMessageProvider<TPayload, TTransportMessage>(this IMessageSerializer<TPayload> messageSerializer, Func<TTransportMessage, TPayload> payloadProvider) => (Type messageType, IReadOnlyDictionary<string, object> messageHeaders, TTransportMessage transportMessage)
+        => messageSerializer.Deserialize(messageType, messageHeaders, payloadProvider(transportMessage), transportMessage);
+}

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/MessageHandler.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/MessageHandler.cs
@@ -54,7 +54,13 @@ public partial class MessageHandler : IMessageHandler
         }
     }
 
-    public async Task<(ProcessResult Result, object Response, Exception ResponseException, string RequestId)> DoHandle(object message, IReadOnlyDictionary<string, object> messageHeaders, IMessageTypeConsumerInvokerSettings consumerInvoker, object transportMessage = null, IDictionary<string, object> consumerContextProperties = null, IServiceProvider currentServiceProvider = null, CancellationToken cancellationToken = default)
+    public async Task<(ProcessResult Result, object Response, Exception ResponseException, string RequestId)> DoHandle(object message,
+                                                                                                                       IReadOnlyDictionary<string, object> messageHeaders,
+                                                                                                                       IMessageTypeConsumerInvokerSettings consumerInvoker,
+                                                                                                                       object transportMessage = null,
+                                                                                                                       IDictionary<string, object> consumerContextProperties = null,
+                                                                                                                       IServiceProvider currentServiceProvider = null,
+                                                                                                                       CancellationToken cancellationToken = default)
     {
         var messageType = message.GetType();
 

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/MessageProcessor.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/MessageProcessor.cs
@@ -89,12 +89,12 @@ public partial class MessageProcessor<TTransportMessage> : MessageHandler, IMess
         try
         {
             messageType = _messageTypeProvider != null
-                ? _messageTypeProvider(transportMessage)
+                ? _messageTypeProvider(transportMessage, messageHeaders)
                 : GetMessageType(messageHeaders);
 
             if (messageType != null)
             {
-                var message = _messageProvider(messageType, transportMessage);
+                    var message = _messageProvider(messageType, messageHeaders, transportMessage);
                 try
                 {
                     var consumerInvokers = TryMatchConsumerInvoker(messageType);

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/ResponseMessageProcessor.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/ResponseMessageProcessor.cs
@@ -95,7 +95,7 @@ public partial class ResponseMessageProcessor<TTransportMessage> : ResponseMessa
                 {
                     // deserialize the response message
                     var response = transportMessage != null
-                        ? _messageProvider(requestState.ResponseType, transportMessage)
+                        ? _messageProvider(requestState.ResponseType, responseHeaders, transportMessage)
                         : null;
 
                     // resolve the response

--- a/src/SlimMessageBus.Host/Helpers/CompatMethods.cs
+++ b/src/SlimMessageBus.Host/Helpers/CompatMethods.cs
@@ -1,11 +1,15 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NET6_0
 
 namespace SlimMessageBus.Host;
+
+#endif
+
+#if NETSTANDARD2_0
 
 /// <summary>
 /// Helper for netstandard2.0
 /// </summary>
-public static class DictionaryExtensions
+public static partial class DictionaryExtensions
 {
     public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> keyValuePair, out TKey key, out TValue value)
     {
@@ -23,7 +27,7 @@ public static class DictionaryExtensions
         return false;
     }
 
-    public static HashSet<T> ToHashSet<T>(this IEnumerable<T> items) => new(items);
+    public static HashSet<T> ToHashSet<T>(this IEnumerable<T> items) => [.. items];
 
     public static IEnumerable<IReadOnlyCollection<T>> Chunk<T>(this IEnumerable<T> items, int size)
     {
@@ -47,13 +51,26 @@ public static class DictionaryExtensions
             yield return chunk;
         }
     }
-
 }
 
 public static class TimeSpanExtensions
 {
     public static TimeSpan Multiply(this TimeSpan timeSpan, double factor)
         => TimeSpan.FromMilliseconds(timeSpan.TotalMilliseconds * factor);
+}
+
+#endif
+
+#if NETSTANDARD2_0 || NET6_0
+
+public static partial class DictionaryExtensions
+{
+    public static IReadOnlyDictionary<string, object> AsReadOnly(this IDictionary<string, object> dict) => dict switch
+    {
+        Dictionary<string, object> d => d,
+        null => null,
+        _ => new Dictionary<string, object>(dict)
+    };
 }
 
 #endif

--- a/src/SlimMessageBus.Host/IMessageHeadersFactory.cs
+++ b/src/SlimMessageBus.Host/IMessageHeadersFactory.cs
@@ -2,5 +2,5 @@
 
 public interface IMessageHeadersFactory
 {
-    IDictionary<string, object> CreateHeaders();
+    Dictionary<string, object> CreateHeaders();
 }

--- a/src/SlimMessageBus.Host/MessageBusBase.cs
+++ b/src/SlimMessageBus.Host/MessageBusBase.cs
@@ -491,9 +491,9 @@ public abstract partial class MessageBusBase : IDisposable, IAsyncDisposable,
     /// Create an instance of message headers.
     /// </summary>
     /// <returns></returns>
-    public virtual IDictionary<string, object> CreateHeaders() => new Dictionary<string, object>(10);
+    public virtual Dictionary<string, object> CreateHeaders() => new(10);
 
-    private IDictionary<string, object> GetMessageHeaders(object message, IDictionary<string, object> headers, ProducerSettings producerSettings)
+    private Dictionary<string, object> GetMessageHeaders(object message, IDictionary<string, object> headers, ProducerSettings producerSettings)
     {
         var messageHeaders = CreateHeaders();
         if (messageHeaders != null)

--- a/src/SlimMessageBus.Host/Producer/InterceptorPipelines/PublishInterceptorPipeline.cs
+++ b/src/SlimMessageBus.Host/Producer/InterceptorPipelines/PublishInterceptorPipeline.cs
@@ -42,7 +42,12 @@ internal class PublishInterceptorPipeline : ProducerInterceptorPipeline<PublishC
         if (!_targetVisited)
         {
             _targetVisited = true;
-            await _bus.ProduceToTransport(_message, _message.GetType(), _context.Path, _context.Headers, _targetBus, _context.CancellationToken);
+            await _bus.ProduceToTransport(_message,
+                                          _message.GetType(),
+                                          _context.Path,
+                                          _context.Headers,
+                                          _targetBus,
+                                          _context.CancellationToken);
             return null;
         }
 

--- a/src/SlimMessageBus.Host/Producer/InterceptorPipelines/SendInterceptorPipeline.cs
+++ b/src/SlimMessageBus.Host/Producer/InterceptorPipelines/SendInterceptorPipeline.cs
@@ -45,7 +45,17 @@ internal class SendInterceptorPipeline<TResponse> : ProducerInterceptorPipeline<
         if (!_targetVisited)
         {
             _targetVisited = true;
-            var response = await _bus.SendInternal<TResponse>(_message, _context.Path, _message.GetType(), typeof(TResponse), _producerSettings, _context.Created, _context.Expires, _context.RequestId, _context.Headers, _targetBus, _context.CancellationToken);
+            var response = await _bus.SendInternal<TResponse>(_message,
+                                                              _context.Path,
+                                                              _message.GetType(),
+                                                              typeof(TResponse),
+                                                              _producerSettings,
+                                                              _context.Created,
+                                                              _context.Expires,
+                                                              _context.RequestId,
+                                                              _context.Headers,
+                                                              _targetBus,
+                                                              _context.CancellationToken);
             return response;
         }
 

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaPartitionConsumerForConsumersTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaPartitionConsumerForConsumersTest.cs
@@ -35,8 +35,16 @@ public class KafkaPartitionConsumerForConsumersTest : IDisposable
         massageBusMock.ServiceProviderMock.ProviderMock.Setup(x => x.GetService(typeof(IPendingRequestManager))).Returns(() => new PendingRequestManager(new InMemoryPendingRequestStore(), TimeProvider.System, NullLoggerFactory.Instance));
 
         var headerSerializer = new StringValueSerializer();
+        var messageProviderMock = new Mock<MessageProvider<ConsumeResult>>();
 
-        _subject = new Lazy<KafkaPartitionConsumerForConsumers>(() => new KafkaPartitionConsumerForConsumers(massageBusMock.Bus.LoggerFactory, [_consumerBuilder.ConsumerSettings], group, _topicPartition, _commitControllerMock.Object, headerSerializer, massageBusMock.Bus));
+        _subject = new Lazy<KafkaPartitionConsumerForConsumers>(() => new KafkaPartitionConsumerForConsumers(massageBusMock.Bus.LoggerFactory,
+                                                                                                             [_consumerBuilder.ConsumerSettings],
+                                                                                                             group,
+                                                                                                             _topicPartition,
+                                                                                                             _commitControllerMock.Object,
+                                                                                                             headerSerializer,
+                                                                                                             messageProviderMock.Object,
+                                                                                                             massageBusMock.Bus));
     }
 
     public void Dispose()

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaPartitionConsumerForResponsesTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaPartitionConsumerForResponsesTest.cs
@@ -96,7 +96,7 @@ public class KafkaPartitionConsumerForResponsesTest : IDisposable
         var pendingRequestState = new PendingRequestState(requestId, request, request.GetType(), response.GetType(), DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(1), default);
         _pendingRequestStore.Setup(x => x.GetById(requestId)).Returns(pendingRequestState);
 
-        _messageProvider.Setup(x => x(response.GetType(), responseTransportMessage)).Returns(response);
+        _messageProvider.Setup(x => x(response.GetType(), It.IsAny<IReadOnlyDictionary<string, object>>(), responseTransportMessage)).Returns(response);
 
         // act
         await _subject.OnMessage(responseTransportMessage);

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/StringValueSerializer.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/StringValueSerializer.cs
@@ -1,16 +1,17 @@
 ﻿namespace SlimMessageBus.Host.Kafka.Test;
 
-using SlimMessageBus.Host.Serialization;
 using System.Text;
+
+using SlimMessageBus.Host.Serialization;
 
 /// <summary>
 /// Serializes any value passed into into UTF-8 string. Prior serialization the value is converted to string using <see cref="object.ToString"/>.
 /// </summary>
 public class StringValueSerializer : IMessageSerializer
 {
-    public object Deserialize(Type t, byte[] payload)
-        => Encoding.UTF8.GetString(payload);
-
-    public byte[] Serialize(Type t, object message)
+    public byte[] Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage)
         => Encoding.UTF8.GetBytes((string)message);
+
+    public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage)
+        => Encoding.UTF8.GetString(payload);
 }

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/DefaultKafkaHeaderSerializerTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/DefaultKafkaHeaderSerializerTest.cs
@@ -17,8 +17,8 @@ public class DefaultKafkaHeaderSerializerTest
         var subject = new DefaultKafkaHeaderSerializer(inferType: inferType);
 
         // act
-        var payload = subject.Serialize(typeof(object), inValue);
-        var actualValue = subject.Deserialize(typeof(object), payload);
+        var payload = subject.Serialize(typeof(object), null, inValue, null);
+        var actualValue = subject.Deserialize(typeof(object), null, payload, null);
 
         // assert
         if (inValue is null)

--- a/src/Tests/SlimMessageBus.Host.Memory.Test/MemoryMessageBusTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Memory.Test/MemoryMessageBusTests.cs
@@ -58,11 +58,11 @@ public class MemoryMessageBusTests
             .Returns(() => new ConsumerContext());
 
         _messageSerializerMock
-            .Setup(x => x.Serialize(It.IsAny<Type>(), It.IsAny<object>()))
-            .Returns((Type type, object message) => Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message)));
+            .Setup(x => x.Serialize(It.IsAny<Type>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<object>(), It.IsAny<object>()))
+            .Returns((Type type, IDictionary<string, object> headers, object message, object transportMessage) => Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message)));
         _messageSerializerMock
-            .Setup(x => x.Deserialize(It.IsAny<Type>(), It.IsAny<byte[]>()))
-            .Returns((Type type, byte[] payload) => JsonConvert.DeserializeObject(Encoding.UTF8.GetString(payload), type));
+            .Setup(x => x.Deserialize(It.IsAny<Type>(), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>(), It.IsAny<object>()))
+            .Returns((Type type, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage) => JsonConvert.DeserializeObject(Encoding.UTF8.GetString(payload), type));
 
         _subject = new Lazy<MemoryMessageBus>(() => new MemoryMessageBus(_settings, _providerSettings));
     }

--- a/src/Tests/SlimMessageBus.Host.Outbox.Test/Interceptors/OutboxForwardingPublishInterceptorTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.Test/Interceptors/OutboxForwardingPublishInterceptorTests.cs
@@ -122,7 +122,7 @@ public static class OutboxForwardingPublishInterceptorTests
             // arrange
             var message = new object();
 
-            _mockSerializer.Setup(x => x.Serialize(typeof(object), message)).Verifiable();
+            _mockSerializer.Setup(x => x.Serialize(typeof(object), new Dictionary<string, object>(), message, null)).Verifiable();
             _mockOutboxFactory.Setup(x => x.Create(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>())).Verifiable();
 
             var nextCalled = 0;
@@ -182,7 +182,7 @@ public static class OutboxForwardingPublishInterceptorTests
             // arrange
             var message = new object();
 
-            _mockSerializer.Setup(x => x.Serialize(typeof(object), message)).Verifiable();
+            _mockSerializer.Setup(x => x.Serialize(typeof(object), new Dictionary<string, object>(), message, null)).Verifiable();
             _mockOutboxFactory.Setup(x => x.Create(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>())).Verifiable();
             _mockOutboxNotificationService.Setup(x => x.Notify()).Verifiable();
 

--- a/src/Tests/SlimMessageBus.Host.Serialization.Benchmark/SerDesBenchmark.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Benchmark/SerDesBenchmark.cs
@@ -1,9 +1,12 @@
 ﻿namespace SlimMessageBus.Host.Serialization.Benchmark;
 
-using global::Avro;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
+
+using global::Avro;
+
 using Microsoft.Extensions.Logging.Abstractions;
+
 using SlimMessageBus.Host.Serialization.Avro;
 using SlimMessageBus.Host.Serialization.Json;
 
@@ -43,8 +46,8 @@ public class SerDesBenchmark
     [Benchmark]
     public void SerDes()
     {
-        var payload = scenario.Serializer.Serialize(scenario.MessageType, scenario.Message);
-        scenario.Serializer.Deserialize(scenario.MessageType, payload);
+        var payload = scenario.Serializer.Serialize(scenario.MessageType, null, scenario.Message, null);
+        scenario.Serializer.Deserialize(scenario.MessageType, null, payload, null);
     }
 
     public class Scenario

--- a/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/GoogleProtobufMessageSerializerTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/GoogleProtobufMessageSerializerTest.cs
@@ -15,6 +15,7 @@ public class GoogleProtobufMessageSerializerTest
     {
         // arrange
         var serializer = new GoogleProtobufMessageSerializer(new NullLoggerFactory());
+        var headers = new Dictionary<string, object>();
 
         // act
         var personMessage = new PersonMessage
@@ -22,10 +23,10 @@ public class GoogleProtobufMessageSerializerTest
             Id = 1,
             Name = "SlimMessageBus"
         };
-        var serializedPerson = serializer.Serialize(personMessage.GetType(), personMessage);
+        var serializedPerson = serializer.Serialize(personMessage.GetType(), headers, personMessage, null);
 
         // assert
-        var deserializedPerson = serializer.Deserialize(typeof(PersonMessage), serializedPerson);
+        var deserializedPerson = serializer.Deserialize(typeof(PersonMessage), headers, serializedPerson, null);
         ((PersonMessage)deserializedPerson).Should().BeEquivalentTo(personMessage);
     }
 }

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/HybridMessageSerializerProviderTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/HybridMessageSerializerProviderTests.cs
@@ -1,5 +1,4 @@
 ﻿namespace SlimMessageBus.Host.Serialization.Hybrid.Test;
-
 public class HybridMessageSerializerProviderTests
 {
     [Fact]
@@ -53,7 +52,7 @@ public class HybridMessageSerializerProviderTests
         var mockDefaultSerializer = new Mock<IMessageSerializerProvider>();
 
         var mockSerializer1 = new Mock<IMessageSerializer>();
-        mockSerializer1.Setup(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>())).Verifiable(Times.Once());
+        mockSerializer1.Setup(x => x.Serialize(typeof(SampleOne), It.IsAny<IDictionary<string, object>>(), It.IsAny<SampleOne>(), It.IsAny<object>())).Verifiable(Times.Once());
 
         var mockSerializerProvider1 = new Mock<IMessageSerializerProvider>();
         mockSerializerProvider1.Setup(x => x.GetSerializer(It.IsAny<string>())).Returns(mockSerializer1.Object);
@@ -67,13 +66,15 @@ public class HybridMessageSerializerProviderTests
             { mockSerializerProvider2.Object, new[] { typeof(SampleTwo) } },
         };
 
+        var headersMock = new Mock<IDictionary<string, object>>();
+
         var target = new HybridMessageSerializerProvider(mockLogger.Object, serializers, mockDefaultSerializer.Object);
 
         // act
-        var _ = target.GetSerializer("").Serialize(typeof(SampleOne), new SampleOne());
+        var _ = target.GetSerializer("").Serialize(typeof(SampleOne), headersMock.Object, new SampleOne(), null);
 
         // assert
-        mockSerializer1.Verify(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>()));
+        mockSerializer1.Verify(x => x.Serialize(typeof(SampleOne), headersMock.Object, It.IsAny<SampleOne>(), null));
         mockSerializer1.VerifyNoOtherCalls();
 
         mockSerializerProvider1.Verify(x => x.GetSerializer(It.IsAny<string>()));
@@ -88,8 +89,10 @@ public class HybridMessageSerializerProviderTests
     public void When_AGenericMessageIsSerialized_Then_UseDefaultSerializer()
     {
         // arrange
+        var headersMock = new Mock<IDictionary<string, object>>();
+
         var mockDefaultSerializer = new Mock<IMessageSerializer>();
-        mockDefaultSerializer.Setup(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>())).Verifiable(Times.Once());
+        mockDefaultSerializer.Setup(x => x.Serialize(typeof(SampleOne), It.IsAny<IDictionary<string, object>>(), It.IsAny<SampleOne>(), It.IsAny<object>())).Verifiable(Times.Once());
 
         var mockDefaultSerializerProvider = new Mock<IMessageSerializerProvider>();
         mockDefaultSerializerProvider.Setup(x => x.GetSerializer(It.IsAny<string>())).Returns(mockDefaultSerializer.Object);
@@ -105,10 +108,10 @@ public class HybridMessageSerializerProviderTests
         var target = new HybridMessageSerializerProvider(mockLogger.Object, serializers, mockDefaultSerializerProvider.Object);
 
         // act
-        var _ = target.GetSerializer("").Serialize(typeof(SampleOne), new SampleOne());
+        var _ = target.GetSerializer("").Serialize(typeof(SampleOne), headersMock.Object, new SampleOne(), null);
 
         // assert
-        mockDefaultSerializer.Verify(x => x.Serialize(typeof(SampleOne), It.IsAny<SampleOne>()));
+        mockDefaultSerializer.Verify(x => x.Serialize(typeof(SampleOne), headersMock.Object, It.IsAny<SampleOne>(), null));
         mockDefaultSerializer.VerifyNoOtherCalls();
 
         mockDefaultSerializerProvider.Verify(x => x.GetSerializer(""));

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SerializationBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SerializationBuilderExtensionsTests.cs
@@ -1,5 +1,7 @@
 namespace SlimMessageBus.Host.Serialization.Hybrid.Test;
 
+using System.Collections.Generic;
+
 using Microsoft.Extensions.DependencyInjection;
 
 public class SerializationBuilderExtensionsTests
@@ -108,12 +110,12 @@ public class SerializationBuilderExtensionsTests
 
     public abstract class AbstractSerializer : IMessageSerializer, IMessageSerializerProvider
     {
-        public object Deserialize(Type t, byte[] payload)
+        public byte[] Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage)
         {
             throw new NotImplementedException();
         }
 
-        public byte[] Serialize(Type t, object message)
+        public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage)
         {
             throw new NotImplementedException();
         }

--- a/src/Tests/SlimMessageBus.Host.Serialization.Json.Test/JsonMessageSerializerTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Json.Test/JsonMessageSerializerTests.cs
@@ -23,8 +23,8 @@ public class JsonMessageSerializerTests
         var subject = new JsonMessageSerializer();
 
         // act
-        var bytes = subject.Serialize(typeof(object), value);
-        var deserializedValue = subject.Deserialize(typeof(object), bytes);
+        var bytes = subject.Serialize(typeof(object), null, value, null);
+        var deserializedValue = subject.Deserialize(typeof(object), null, bytes, null);
 
         // assert
         deserializedValue.Should().Be(expectedValue);
@@ -38,8 +38,8 @@ public class JsonMessageSerializerTests
         var subject = new JsonMessageSerializer() as IMessageSerializer<string>;
 
         // act
-        var json = subject.Serialize(typeof(object), value);
-        var deserializedValue = subject.Deserialize(typeof(object), json);
+        var json = subject.Serialize(typeof(object), null, value, null);
+        var deserializedValue = subject.Deserialize(typeof(object), null, json, null);
 
         // assert
         deserializedValue.Should().Be(expectedValue);

--- a/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/JsonMessageSerializerTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/JsonMessageSerializerTests.cs
@@ -20,9 +20,9 @@ public class JsonMessageSerializerTests
         // arrange
         var subject = new JsonMessageSerializer();
 
-        // act
-        var bytes = subject.Serialize(typeof(object), value);
-        var deserializedValue = subject.Deserialize(typeof(object), bytes);
+        // actx
+        var bytes = subject.Serialize(typeof(object), null, value, null);
+        var deserializedValue = subject.Deserialize(typeof(object), null, bytes, null);
 
         // assert
         deserializedValue.Should().Be(expectedValue);
@@ -36,8 +36,8 @@ public class JsonMessageSerializerTests
         var subject = new JsonMessageSerializer() as IMessageSerializer<string>;
 
         // act
-        var json = subject.Serialize(typeof(object), value);
-        var deserializedValue = subject.Deserialize(typeof(object), json);
+        var json = subject.Serialize(typeof(object), null, value, null);
+        var deserializedValue = subject.Deserialize(typeof(object), null, json, null);
 
         // assert
         deserializedValue.Should().Be(expectedValue);

--- a/src/Tests/SlimMessageBus.Host.Test/Consumer/ConsumerInstanceMessageProcessorTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Consumer/ConsumerInstanceMessageProcessorTest.cs
@@ -27,11 +27,11 @@ public class ConsumerInstanceMessageProcessorTest
         var mockMessage = new Mock<IAsyncDisposable>();
         mockMessage.Setup(x => x.DisposeAsync()).Verifiable();
 
-        object MessageProvider(Type messageType, byte[] payload) => mockMessage.Object;
+        object MessageProvider(Type messageType, IReadOnlyDictionary<string, object> messageHeaders, object transportMessage) => mockMessage.Object;
 
         var p = new MessageProcessor<byte[]>([_handlerSettings], _busMock.Bus, MessageProvider, "path", responseProducer: _busMock.Bus);
 
-        _busMock.SerializerMock.Setup(x => x.Deserialize(typeof(SomeRequest), It.IsAny<byte[]>())).Returns(mockMessage.Object);
+        _busMock.SerializerMock.Setup(x => x.Deserialize(typeof(SomeRequest), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>(), It.IsAny<object>())).Returns(mockMessage.Object);
 
         // act
         await p.ProcessMessage(_transportMessage, new Dictionary<string, object>(), default);
@@ -48,11 +48,11 @@ public class ConsumerInstanceMessageProcessorTest
         mockMessage.Setup(x => x.DisposeAsync()).Verifiable();
         mockMessage.Setup(x => x.Dispose()).Verifiable();
 
-        object MessageProvider(Type messageType, byte[] payload) => mockMessage.Object;
+        object MessageProvider(Type messageType, IReadOnlyDictionary<string, object> messageHeaders, object transportMessage) => mockMessage.Object;
 
-        var p = new MessageProcessor<byte[]>(new[] { _handlerSettings }, _busMock.Bus, MessageProvider, "path", responseProducer: _busMock.Bus);
+        var p = new MessageProcessor<byte[]>([_handlerSettings], _busMock.Bus, MessageProvider, "path", responseProducer: _busMock.Bus);
 
-        _busMock.SerializerMock.Setup(x => x.Deserialize(typeof(SomeRequest), It.IsAny<byte[]>())).Returns(mockMessage.Object);
+        _busMock.SerializerMock.Setup(x => x.Deserialize(typeof(SomeRequest), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>(), It.IsAny<object>())).Returns(mockMessage.Object);
 
         // act
         await p.ProcessMessage(_transportMessage, new Dictionary<string, object>(), default);
@@ -69,11 +69,11 @@ public class ConsumerInstanceMessageProcessorTest
         var mockMessage = new Mock<IDisposable>();
         mockMessage.Setup(x => x.Dispose()).Verifiable();
 
-        object MessageProvider(Type messageType, byte[] payload) => mockMessage.Object;
+        object MessageProvider(Type messageType, IReadOnlyDictionary<string, object> messageHeaders, object transportMessage) => mockMessage.Object;
 
-        var p = new MessageProcessor<byte[]>(new[] { _handlerSettings }, _busMock.Bus, MessageProvider, "path", responseProducer: _busMock.Bus);
+        var p = new MessageProcessor<byte[]>([_handlerSettings], _busMock.Bus, MessageProvider, "path", responseProducer: _busMock.Bus);
 
-        _busMock.SerializerMock.Setup(x => x.Deserialize(typeof(SomeRequest), It.IsAny<byte[]>())).Returns(mockMessage.Object);
+        _busMock.SerializerMock.Setup(x => x.Deserialize(typeof(SomeRequest), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>(), It.IsAny<object>())).Returns(mockMessage.Object);
 
         // act
         await p.ProcessMessage(_transportMessage, new Dictionary<string, object>(), default);
@@ -91,11 +91,11 @@ public class ConsumerInstanceMessageProcessorTest
         headers.SetHeader(ReqRespMessageHeaders.Expires, _busMock.TimeProvider.GetUtcNow().Subtract(TimeSpan.FromSeconds(10)));
         headers.SetHeader(ReqRespMessageHeaders.RequestId, requestId);
 
-        object MessageProvider(Type messageType, byte[] payload) => request;
+        object MessageProvider(Type messageType, IReadOnlyDictionary<string, object> messageHeaders, object transportMessage) => request;
 
         var p = new MessageProcessor<byte[]>([_handlerSettings], _busMock.Bus, MessageProvider, "path", responseProducer: _busMock.Bus);
 
-        _busMock.SerializerMock.Setup(x => x.Deserialize(typeof(SomeRequest), It.IsAny<byte[]>())).Returns(request);
+        _busMock.SerializerMock.Setup(x => x.Deserialize(typeof(SomeRequest), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>(), It.IsAny<object>())).Returns(request);
 
         // act
         await p.ProcessMessage(_transportMessage, headers, default);
@@ -118,11 +118,11 @@ public class ConsumerInstanceMessageProcessorTest
         var headers = new Dictionary<string, object>();
         headers.SetHeader(ReqRespMessageHeaders.RequestId, requestId);
         headers.SetHeader(ReqRespMessageHeaders.ReplyTo, replyTo);
-        object MessageProvider(Type messageType, byte[] payload) => request;
+        object MessageProvider(Type messageType, IReadOnlyDictionary<string, object> messageHeaders, object transportMessage) => request;
 
         var p = new MessageProcessor<byte[]>([_handlerSettings], _busMock.Bus, MessageProvider, _topic, responseProducer: _busMock.Bus);
 
-        _busMock.SerializerMock.Setup(x => x.Deserialize(typeof(SomeRequest), It.IsAny<byte[]>())).Returns(request);
+        _busMock.SerializerMock.Setup(x => x.Deserialize(typeof(SomeRequest), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>(), It.IsAny<object>())).Returns(request);
 
         var ex = new Exception("Something went bad");
         _busMock.HandlerMock.Setup(x => x.OnHandle(request, It.IsAny<CancellationToken>())).Returns(Task.FromException<SomeResponse>(ex));
@@ -154,7 +154,7 @@ public class ConsumerInstanceMessageProcessorTest
         // arrange
         var message = new SomeMessage();
         var messageHeaders = new Dictionary<string, object>();
-        _messageProviderMock.Setup(x => x(message.GetType(), It.IsAny<byte[]>())).Returns(message);
+        _messageProviderMock.Setup(x => x(message.GetType(), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>())).Returns(message);
 
         var ex = new Exception("Something went bad");
         _busMock.ConsumerMock.Setup(x => x.OnHandle(message, It.IsAny<CancellationToken>())).ThrowsAsync(ex);
@@ -195,7 +195,7 @@ public class ConsumerInstanceMessageProcessorTest
         // arrange
         var message = new SomeMessage();
 
-        _messageProviderMock.Setup(x => x(message.GetType(), It.IsAny<byte[]>())).Returns(message);
+        _messageProviderMock.Setup(x => x(message.GetType(), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>())).Returns(message);
         _busMock.ConsumerMock.Setup(x => x.OnHandle(message, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
         var p = new MessageProcessor<byte[]>([_consumerSettings], _busMock.Bus, _messageProviderMock.Object, _topic, responseProducer: _busMock.Bus);
@@ -228,7 +228,7 @@ public class ConsumerInstanceMessageProcessorTest
             .Setup(x => x.GetService(typeof(IEnumerable<IConsumerInterceptor<SomeMessage>>)))
             .Returns(new[] { messageConsumerInterceptor.Object });
 
-        _messageProviderMock.Setup(x => x(message.GetType(), It.IsAny<byte[]>())).Returns(message);
+        _messageProviderMock.Setup(x => x(message.GetType(), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>())).Returns(message);
         _busMock.ConsumerMock.Setup(x => x.OnHandle(message, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
         var p = new MessageProcessor<byte[]>([_consumerSettings], _busMock.Bus, _messageProviderMock.Object, _topic, responseProducer: _busMock.Bus);
@@ -277,7 +277,7 @@ public class ConsumerInstanceMessageProcessorTest
             .Setup(x => x.ProduceResponse(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<object>(), It.IsAny<Exception>(), It.IsAny<IMessageTypeConsumerInvokerSettings>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _messageProviderMock.Setup(x => x(request.GetType(), requestPayload)).Returns(request);
+        _messageProviderMock.Setup(x => x(request.GetType(), It.IsAny<IReadOnlyDictionary<string, object>>(), requestPayload)).Returns(request);
 
         var p = new MessageProcessor<byte[]>([_handlerSettings], _busMock.Bus, _messageProviderMock.Object, _topic, responseProducer: _busMock.Bus);
 
@@ -326,7 +326,7 @@ public class ConsumerInstanceMessageProcessorTest
 
         var consumerSettings = new HandlerBuilder<SomeRequestWithoutResponse>(_busMock.Bus.Settings).Topic(_topic).WithHandler<IRequestHandler<SomeRequestWithoutResponse>>().ConsumerSettings;
 
-        _messageProviderMock.Setup(x => x(request.GetType(), requestPayload)).Returns(request);
+        _messageProviderMock.Setup(x => x(request.GetType(), It.IsAny<IReadOnlyDictionary<string, object>>(), requestPayload)).Returns(request);
 
         var p = new MessageProcessor<byte[]>([consumerSettings], _busMock.Bus, _messageProviderMock.Object, _topic, responseProducer: _busMock.Bus);
 
@@ -370,7 +370,7 @@ public class ConsumerInstanceMessageProcessorTest
 
         var consumerSettings = new ConsumerBuilder<SomeMessage>(_busMock.Bus.Settings).Topic(_topic).WithConsumer<SomeMessageConsumerWithContext>().ConsumerSettings;
 
-        _messageProviderMock.Setup(x => x(message.GetType(), _transportMessage)).Returns(message);
+        _messageProviderMock.Setup(x => x(message.GetType(), It.IsAny<IReadOnlyDictionary<string, object>>(), _transportMessage)).Returns(message);
 
         var p = new MessageProcessor<byte[]>([consumerSettings], _busMock.Bus, _messageProviderMock.Object, _topic, responseProducer: _busMock.Bus);
 
@@ -398,7 +398,7 @@ public class ConsumerInstanceMessageProcessorTest
 
         var message = new SomeMessage();
 
-        _messageProviderMock.Setup(x => x(message.GetType(), It.IsAny<byte[]>())).Returns(message);
+        _messageProviderMock.Setup(x => x(message.GetType(), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>())).Returns(message);
         _busMock.ConsumerMock.Setup(x => x.OnHandle(message, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
         var p = new MessageProcessor<byte[]>([consumerSettings], _busMock.Bus, _messageProviderMock.Object, _topic, responseProducer: _busMock.Bus);
@@ -478,8 +478,8 @@ public class ConsumerInstanceMessageProcessorTest
             _topic,
             responseProducer: _busMock.Bus);
 
-        _busMock.SerializerMock.Setup(x => x.Deserialize(message.GetType(), _transportMessage)).Returns(message);
-        messageWithHeaderProviderMock.Setup(x => x(message.GetType(), _transportMessage)).Returns(message);
+        _busMock.SerializerMock.Setup(x => x.Deserialize(message.GetType(), mesageHeaders, _transportMessage, It.IsAny<object>())).Returns(message);
+        messageWithHeaderProviderMock.Setup(x => x(message.GetType(), It.IsAny<IReadOnlyDictionary<string, object>>(), _transportMessage)).Returns(message);
 
         var someMessageConsumerMock = new Mock<IConsumer<SomeMessage>>();
         var someMessageInterfaceConsumerMock = new Mock<IConsumer<ISomeMessageMarkerInterface>>();

--- a/src/Tests/SlimMessageBus.Host.Test/Consumer/MessageProcessorTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Consumer/MessageProcessorTest.cs
@@ -60,14 +60,14 @@ public class MessageProcessorTest
         var deserializationException = new InvalidOperationException("Deserialization failed");
 
         messageProviderMock
-            .Setup(x => x.Invoke(typeof(SomeMessage), transportMessageMock.Object))
+            .Setup(x => x.Invoke(typeof(SomeMessage), headers, transportMessageMock.Object))
             .Throws(deserializationException);
 
         // act
         var result = await subject.Value.ProcessMessage(transportMessageMock.Object, headers);
 
         // assert
-        messageProviderMock.Verify(x => x(typeof(SomeMessage), transportMessageMock.Object), Times.Once);
+        messageProviderMock.Verify(x => x(typeof(SomeMessage), headers, transportMessageMock.Object), Times.Once);
         messageProviderMock.VerifyNoOtherCalls();
 
         result.Should().NotBeNull();

--- a/src/Tests/SlimMessageBus.Host.Test/Consumer/ResponseMessageProcessorTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Consumer/ResponseMessageProcessorTest.cs
@@ -90,7 +90,7 @@ public class ResponseMessageProcessorTest
         var requestId = "requestId";
         var response = new object();
 
-        _messageProviderMock.Setup(x => x(response.GetType(), _transportMessage)).Returns(response);
+        _messageProviderMock.Setup(x => x(response.GetType(), It.IsAny<IReadOnlyDictionary<string, object>>(), _transportMessage)).Returns(response);
 
         _messageHeaders[ReqRespMessageHeaders.RequestId] = requestId;
 
@@ -123,7 +123,7 @@ public class ResponseMessageProcessorTest
         var requestId = "requestId";
         var ex = new Exception("Boom!");
 
-        _messageProviderMock.Setup(x => x(typeof(object), _transportMessage)).Throws(ex);
+        _messageProviderMock.Setup(x => x(typeof(object), It.IsAny<IReadOnlyDictionary<string, object>>(), _transportMessage)).Throws(ex);
 
         _messageHeaders[ReqRespMessageHeaders.RequestId] = requestId;
 

--- a/src/Tests/SlimMessageBus.Host.Test/Hybrid/HybridMessageBusTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Hybrid/HybridMessageBusTest.cs
@@ -30,11 +30,11 @@ public class HybridMessageBusTest
         _messageBusBuilder.Settings.ServiceProvider = _serviceProviderMock.Object;
 
         _messageSerializerMock
-            .Setup(x => x.Serialize(It.IsAny<Type>(), It.IsAny<object>()))
-            .Returns((Type type, object message) => Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message)));
+            .Setup(x => x.Serialize(It.IsAny<Type>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<object>(), It.IsAny<object>()))
+            .Returns((Type type, IDictionary<string, object> headers, object message, object transportMessage) => Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message)));
         _messageSerializerMock
-            .Setup(x => x.Deserialize(It.IsAny<Type>(), It.IsAny<byte[]>()))
-            .Returns((Type type, byte[] payload) => JsonConvert.DeserializeObject(Encoding.UTF8.GetString(payload), type));
+            .Setup(x => x.Deserialize(It.IsAny<Type>(), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>(), It.IsAny<object>()))
+            .Returns((Type type, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage) => JsonConvert.DeserializeObject(Encoding.UTF8.GetString(payload), type));
 
         _serviceProviderMock.Setup(x => x.GetService(typeof(IMessageSerializer))).Returns(_messageSerializerMock.Object);
         _serviceProviderMock.Setup(x => x.GetService(typeof(IMessageTypeResolver))).Returns(new AssemblyQualifiedNameMessageTypeResolver());
@@ -68,7 +68,7 @@ public class HybridMessageBusTest
             mbb.Produce<SomeRequest>(x => x.DefaultTopic("topic4"));
             mbb.WithProvider(mbs =>
             {
-                _bus2Mock = new Mock<MessageBusBase>(new[] { mbs });
+                _bus2Mock = new Mock<MessageBusBase>([mbs]);
                 _bus2Mock.SetupGet(x => x.Settings).Returns(mbs);
 
                 _bus2Mock.Setup(x => x.ProducePublish(It.IsAny<SomeMessage>(), It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<IMessageBusTarget>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);

--- a/src/Tests/SlimMessageBus.Host.Test/Interceptors/PublishInterceptorPipelineTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Interceptors/PublishInterceptorPipelineTests.cs
@@ -5,12 +5,7 @@ using SlimMessageBus.Host.Interceptor;
 
 public class PublishInterceptorPipelineTests
 {
-    private readonly MessageBusMock _busMock;
-
-    public PublishInterceptorPipelineTests()
-    {
-        _busMock = new MessageBusMock();
-    }
+    private readonly MessageBusMock _busMock = new();
 
     [Theory]
     [InlineData(false, false)]

--- a/src/Tests/SlimMessageBus.Host.Test/MessageBusTested.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/MessageBusTested.cs
@@ -23,7 +23,7 @@ public class MessageBusTested : MessageBusBase
 
         if (Settings.RequestResponse != null)
         {
-            RequestResponseMessageProcessor = new ResponseMessageProcessor<object>(LoggerFactory, Settings.RequestResponse, (mt, m) => m, PendingRequestStore, TimeProvider);
+            RequestResponseMessageProcessor = new ResponseMessageProcessor<object>(LoggerFactory, Settings.RequestResponse, (mt, h, m) => m, PendingRequestStore, TimeProvider);
             AddConsumer(new MessageBusTestedConsumer(NullLogger.Instance));
         }
     }
@@ -56,8 +56,8 @@ public class MessageBusTested : MessageBusBase
         if (messageType.GetInterfaces().Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IRequest<>)))
         {
             var messageSerializer = SerializerProvider.GetSerializer(path);
-            var messagePayload = messageSerializer.Serialize(messageType, message);
-            var req = messageSerializer.Deserialize(messageType, messagePayload);
+            var messagePayload = messageSerializer.Serialize(messageType, messageHeaders, message, null);
+            var req = messageSerializer.Deserialize(messageType, messageHeaders.AsReadOnly(), messagePayload, null);
 
             var resp = OnReply(messageType, path, req);
             if (resp == null)

--- a/src/Tests/SlimMessageBus.Host.Test/MessageWithHeadersSerializerTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/MessageWithHeadersSerializerTests.cs
@@ -17,11 +17,11 @@ public class MessageWithHeadersSerializerTests
     public void When_Deserialize_Given_WithoutHeaders_Then_SerializationWorks()
     {
         // arrange
-        var m = new MessageWithHeaders(_payload, new Dictionary<string, object>());
+        var m = new MessageWithHeaders(_payload, []);
 
         // act
-        var payload = _serializer.Serialize(typeof(MessageWithHeaders), m);
-        var m2 = (MessageWithHeaders)_serializer.Deserialize(typeof(MessageWithHeaders), payload);
+        var payload = _serializer.Serialize(typeof(MessageWithHeaders), null, m, null);
+        var m2 = (MessageWithHeaders)_serializer.Deserialize(typeof(MessageWithHeaders), null, payload, null);
 
         // assert
         m2.Headers.Count.Should().Be(0);
@@ -32,11 +32,11 @@ public class MessageWithHeadersSerializerTests
     public void When_Serialize_Given_WithoutPayload_Then_SerializationWorks()
     {
         // arrange
-        var m = new MessageWithHeaders(null, new Dictionary<string, object>());
+        var m = new MessageWithHeaders(null, []);
 
         // act
-        var payload = _serializer.Serialize(typeof(MessageWithHeaders), m);
-        var m2 = (MessageWithHeaders)_serializer.Deserialize(typeof(MessageWithHeaders), payload);
+        var payload = _serializer.Serialize(typeof(MessageWithHeaders), null, m, null);
+        var m2 = (MessageWithHeaders)_serializer.Deserialize(typeof(MessageWithHeaders), null, payload, null);
 
         // assert
         m2.Headers.Count.Should().Be(0);
@@ -61,8 +61,8 @@ public class MessageWithHeadersSerializerTests
             });
 
         // act
-        var payload = _serializer.Serialize(typeof(MessageWithHeaders), m);
-        var m2 = (MessageWithHeaders)_serializer.Deserialize(typeof(MessageWithHeaders), payload);
+        var payload = _serializer.Serialize(typeof(MessageWithHeaders), null, m, null);
+        var m2 = (MessageWithHeaders)_serializer.Deserialize(typeof(MessageWithHeaders), null, payload, null);
 
         // assert
         m2.Headers.Count.Should().Be(m.Headers.Count);
@@ -91,8 +91,8 @@ public class MessageWithHeadersSerializerTests
 
 
         // act
-        var payload = _serializer.Serialize(typeof(MessageWithHeaders), m);
-        var m2 = (MessageWithHeaders)_serializer.Deserialize(typeof(MessageWithHeaders), payload);
+        var payload = _serializer.Serialize(typeof(MessageWithHeaders), null, m, null);
+        var m2 = (MessageWithHeaders)_serializer.Deserialize(typeof(MessageWithHeaders), null, payload, null);
 
         // assert
         m2.Headers.Count.Should().Be(1);


### PR DESCRIPTION
- Extended the `IMessageSerializer` methods to accept message headers and native transport message object.
- Allows to use of message headers to convey information about compression, message type or formatting.
- In some transports like Azure Service Bus, having access to the native [`ServiceBusRecievedMessage`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceivedmessage) type allows the use of `ContentType` and `Label` message properties.

Please have a look at #403 for the discussion.