### PR TITLE
[Host] Correct interface checks for IMessageSerializerProvider

### DIFF
--- a/src/SlimMessageBus.Host.Configuration/Builders/MessageBusBuilder.cs
+++ b/src/SlimMessageBus.Host.Configuration/Builders/MessageBusBuilder.cs
@@ -236,22 +236,22 @@ public class MessageBusBuilder : IHasPostConfigurationActions, ISerializationBui
     }
 
     /// <summary>
-    /// Serializer type (<see cref="IMessageSerializer"/>) to look up in the DI for this bus.
+    /// Serializer type (<see cref="IMessageSerializerProvider"/>) to look up in the DI for this bus.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public MessageBusBuilder WithSerializer<T>() where T : IMessageSerializer => WithSerializer(typeof(T));
+    public MessageBusBuilder WithSerializer<T>() where T : IMessageSerializerProvider => WithSerializer(typeof(T));
 
     /// <summary>
-    /// Serializer type (<see cref="IMessageSerializer"/>) to look up in the DI for this bus.
+    /// Serializer type (<see cref="IMessageSerializerProvider"/>) to look up in the DI for this bus.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     public MessageBusBuilder WithSerializer(Type serializerType)
     {
-        if (serializerType is not null && !typeof(IMessageSerializer).IsAssignableFrom(serializerType))
+        if (serializerType is not null && !typeof(IMessageSerializerProvider).IsAssignableFrom(serializerType))
         {
-            throw new ConfigurationMessageBusException($"The serializer type {serializerType.FullName} does not implement the interface {nameof(IMessageSerializer)}");
+            throw new ConfigurationMessageBusException($"The serializer type {serializerType.FullName} does not implement the interface {nameof(IMessageSerializerProvider)}");
         }
 
         Settings.SerializerType = serializerType ?? throw new ArgumentNullException(nameof(serializerType));
@@ -264,10 +264,6 @@ public class MessageBusBuilder : IHasPostConfigurationActions, ISerializationBui
         PostConfigurationActions.Add(services);
         PostConfigurationActions.Add(services => services.TryAddSingleton<IMessageSerializerProvider>(sp => sp.GetRequiredService<TMessageSerializerProvider>()));
     }
-
-    [Obsolete("Use WithServiceProvider()")]
-    public MessageBusBuilder WithDependencyResolver(IServiceProvider serviceProvider)
-        => WithServiceProvider(serviceProvider);
 
     public MessageBusBuilder WithServiceProvider(IServiceProvider serviceProvider)
     {

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/MessageProcessor.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/MessageProcessor.cs
@@ -94,7 +94,7 @@ public partial class MessageProcessor<TTransportMessage> : MessageHandler, IMess
 
             if (messageType != null)
             {
-                    var message = _messageProvider(messageType, messageHeaders, transportMessage);
+                var message = _messageProvider(messageType, messageHeaders, transportMessage);
                 try
                 {
                     var consumerInvokers = TryMatchConsumerInvoker(messageType);

--- a/src/SlimMessageBus.Host/MessageBusSettingsExtensions.cs
+++ b/src/SlimMessageBus.Host/MessageBusSettingsExtensions.cs
@@ -2,11 +2,7 @@
 
 public static class MessageBusSettingsExtensions
 {
-    public static IMessageSerializer GetSerializer(this MessageBusSettings settings, IServiceProvider serviceProvider) =>
-        (IMessageSerializer)serviceProvider.GetService(settings.SerializerType)
-            ?? throw new ConfigurationMessageBusException($"The bus {settings.Name} could not resolve the required message serializer type {settings.SerializerType.Name} from {nameof(serviceProvider)}");
-
     public static IMessageSerializerProvider GetSerializerProvider(this MessageBusSettings settings, IServiceProvider serviceProvider) =>
-        (IMessageSerializerProvider)serviceProvider.GetService(settings.SerializerType)
-            ?? throw new ConfigurationMessageBusException($"The bus {settings.Name} could not resolve the required message serializer type {settings.SerializerType.Name} from {nameof(serviceProvider)}");
+        serviceProvider.GetService(settings.SerializerType) as IMessageSerializerProvider
+            ?? throw new ConfigurationMessageBusException($"The bus {settings.Name} could not resolve the required {nameof(IMessageSerializerProvider)} of type {settings.SerializerType.Name} from {nameof(serviceProvider)}");
 }


### PR DESCRIPTION
The `.WithSerializer<T>()` and `.WithSerializer(Type)` where checking for the provided type to implement the `IMessageSerializer` interface, where they should be checking for `IMessageSerializerProvder` after the #370 feature.