### PR TITLE
[Host.AzureServiceBus][Host.AzureEventHub] Fix the batch publish chunking iterations

### DIFF
--- a/src/Host.Plugin.Properties.xml
+++ b/src/Host.Plugin.Properties.xml
@@ -4,7 +4,7 @@
   <Import Project="Common.NuGet.Properties.xml" />
 
   <PropertyGroup>
-    <Version>3.3.1-rc103</Version>
+    <Version>3.3.1</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusMessageBus.cs
+++ b/src/SlimMessageBus.Host.AzureServiceBus/ServiceBusMessageBus.cs
@@ -251,22 +251,32 @@ public class ServiceBusMessageBus : MessageBusBase<ServiceBusMessageBusSettings>
                 {
                     inBatch.Add(item.Envelope);
                     advance = it.MoveNext();
-                    if (advance)
-                    {
-                        continue;
-                    }
                 }
-
-                if (batch.Count == 0)
+                else
                 {
-                    throw new ProducerMessageBusException($"Failed to add message {item.Envelope.Message} of Type {item.Envelope.MessageType?.Name} on Path {path} to an empty batch");
-                }
+                    // Current message doesn't fit in this batch
+                    if (batch.Count == 0)
+                    {
+                        throw new ProducerMessageBusException($"Failed to add message {item.Envelope.Message} of Type {item.Envelope.MessageType?.Name} on Path {path} to an empty batch");
+                    }
 
-                advance = false;
+                    // Send the current batch and retry with the current message in a new batch
+                    await SendBatchAsync(path, senderClient, envelopes, batch, cancellationToken).ConfigureAwait(false);
+                    dispatched.AddRange(inBatch);
+                    inBatch.Clear();
+
+                    batch.Dispose();
+                    batch = null;
+                    // Don't advance - retry the current message in the next iteration
+                }
+            }
+
+            // Send any remaining messages in the final batch
+            if (batch != null && batch.Count > 0)
+            {
                 await SendBatchAsync(path, senderClient, envelopes, batch, cancellationToken).ConfigureAwait(false);
                 dispatched.AddRange(inBatch);
-                inBatch.Clear();
-
+                
                 batch.Dispose();
                 batch = null;
             }

--- a/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
+++ b/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
@@ -6,7 +6,7 @@
     <Description>Core configuration interfaces of SlimMessageBus</Description>
     <PackageTags>SlimMessageBus</PackageTags>
     <RootNamespace>SlimMessageBus.Host</RootNamespace>
-    <Version>3.3.1-rc103</Version>
+    <Version>3.3.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Summary

Fixes an issue in the Bulk Message Publish API where message chunking could fail at chunk boundaries, causing some messages to be skipped.

# Details

The problem occurred because chunking was adaptive - based on the buffer capacity reported by Azure Service Bus (ASB) or Azure Event Hubs (AEH) - and varied with message size. When large batches of messages were published at once via the Bulk Message API, this sometimes resulted in incorrect chunking and message loss at the boundary.

# Fix

This PR corrects the chunking logic to ensure all messages are properly published without being skipped.

# Affected Transports

- Azure Service Bus
- Azure Event Hubs