### PR TITLE
[Host.RabbitMQ] Improve Validation and Default Exchange Handling

### DIFF
--- a/docs/provider_rabbitmq.md
+++ b/docs/provider_rabbitmq.md
@@ -362,10 +362,40 @@ services.AddSlimMessageBus((mbb) =>
 Avoiding the call `applyDefaultTopology()` will suppress the SMB inferred topology creation.
 This might be useful in case the SMB inferred topology is not desired or there are other custom needs.
 
-## Not Supported
+### Default Exchange
 
-- [Default type exchanges](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default) are not yet supported
-- Broker generated queues are not yet supported.
+In RabbitMQ, the default exchange (sometimes referred to as the default direct exchange) is a pre-declared, nameless direct exchange with a special behavior:
+
+- Its name is an empty string (`""`).
+- It is of type direct.
+- Every queue that you declare is automatically bound to this default exchange with a routing key equal to the queue’s name.
+
+This means:
+
+- When you publish a message to the default exchange (exchange name = `""`) with a routing key set to the queue name, the message is delivered directly to that queue — no explicit binding is needed.
+
+Example:
+
+```csharp
+channel.basic_publish(
+    exchange: "",             // default exchange
+    routing_key: "my_queue",  // must match the queue name
+    body: Encoding.UTF8.GetBytes("Hello World!")
+);
+```
+
+This will deliver the message straight to the `my_queue` queue.
+
+### Why it exists
+
+The default exchange makes it easy to send messages directly to a queue without having to explicitly set up an exchange and binding. It’s often used for simple "Hello World" style examples and direct queue messaging.
+
+✅ **Key points to remember**
+
+- The default exchange has no name (`""`).
+- Type: direct.
+- Auto-binds every queue by its own name.
+- Messages published to it must use the queue’s name as the routing key.
 
 ## Recipes
 

--- a/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBusSettingsValidationService.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBusSettingsValidationService.cs
@@ -20,8 +20,6 @@ internal class RabbitMqMessageBusSettingsValidationService : DefaultMessageBusSe
 
     protected override void AssertProducer(ProducerSettings producerSettings)
     {
-        base.AssertProducer(producerSettings);
-
         var exchangeName = producerSettings.DefaultPath;
         if (exchangeName == null)
         {
@@ -42,7 +40,20 @@ internal class RabbitMqMessageBusSettingsValidationService : DefaultMessageBusSe
 
     protected override void AssertConsumer(ConsumerSettings consumerSettings)
     {
-        base.AssertConsumer(consumerSettings);
+        if (consumerSettings == null) throw new ArgumentNullException(nameof(consumerSettings));
+
+        if (consumerSettings.MessageType == null)
+        {
+            ThrowConsumerFieldNotSet(consumerSettings, nameof(consumerSettings.MessageType));
+        }
+        if (consumerSettings.ConsumerType == null)
+        {
+            ThrowConsumerFieldNotSet(consumerSettings, nameof(consumerSettings.ConsumerType));
+        }
+        if (consumerSettings.ConsumerMethod == null)
+        {
+            ThrowConsumerFieldNotSet(consumerSettings, nameof(consumerSettings.ConsumerMethod));
+        }
 
         var exchangeName = consumerSettings.Path;
         if (exchangeName == null)

--- a/src/SlimMessageBus.Host.RabbitMQ/RabbitMqTopologyService.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/RabbitMqTopologyService.cs
@@ -80,6 +80,12 @@ public class RabbitMqTopologyService
     {
         var bindingRoutingKey = settings.GetBindingRoutingKey(_providerSettings) ?? string.Empty;
 
+        if (string.IsNullOrEmpty(bindingExchangeName))
+        {
+            _logger.LogInformation("Skipping binding for queue {QueueName} because exchange is default (empty string)", queueName);
+            return;
+        }
+
         _logger.LogInformation("Binding queue {QueueName} to exchange {ExchangeName} using routing key {RoutingKey}", queueName, bindingExchangeName, bindingRoutingKey);
         try
         {
@@ -136,6 +142,12 @@ public class RabbitMqTopologyService
 
     private void DeclareExchange(HasProviderExtensions settings, string exchangeName)
     {
+        if (string.IsNullOrEmpty(exchangeName))
+        {
+            _logger.LogInformation("Skipping exchange declaration because exchange name is default (empty string)");
+            return;
+        }
+
         var exchangeType = settings.GetOrDefault(RabbitMqProperties.ExchangeType, _providerSettings, global::RabbitMQ.Client.ExchangeType.Fanout);
         var durable = settings.GetOrDefault(RabbitMqProperties.ExchangeDurable, _providerSettings, false);
         var autoDelete = settings.GetOrDefault(RabbitMqProperties.ExchangeAutoDelete, _providerSettings, false);
@@ -146,6 +158,12 @@ public class RabbitMqTopologyService
 
     private void DeclareExchange(string exchangeName, string exchangeType, bool durable, bool autoDelete, IDictionary<string, object> arguments = null)
     {
+        if (string.IsNullOrEmpty(exchangeName))
+        {
+            _logger.LogInformation("Skipping exchange declaration because exchange name is default (empty string)");
+            return;
+        }
+
         _logger.LogInformation("Declaring exchange {ExchangeName}, ExchangeType: {ExchangeType}, Durable: {Durable}, AutoDelete: {AutoDelete}", exchangeName, exchangeType, durable, autoDelete);
         try
         {

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/IntegrationTests/RabbitMqDefaultExchangeIt.cs
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/IntegrationTests/RabbitMqDefaultExchangeIt.cs
@@ -1,0 +1,90 @@
+﻿namespace SlimMessageBus.Host.RabbitMQ.Test.IntegrationTests;
+
+using System.Linq;
+using System.Net.Mime;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Configuration;
+
+using SlimMessageBus.Host.Serialization.Json;
+using SlimMessageBus.Host.Test.Common.IntegrationTest;
+
+[Trait("Category", "Integration")]
+[Trait("Transport", "RabbitMQ")]
+public class RabbitMqDefaultExchangeIt(ITestOutputHelper output) : BaseIntegrationTest<RabbitMqDefaultExchangeIt>(output)
+{
+    [Fact]
+    public async Task PublishDirectlyToQueueUsingDefaultExchange()
+    {
+        const string queueName = "default-exchange-queue";
+
+        AddBusConfiguration(mbb =>
+        {
+            mbb.Produce<PingMessage>(x => x
+               .DefaultPath(string.Empty)
+               .RoutingKeyProvider((m, ctx) => queueName)
+               .MessagePropertiesModifier((m, p) =>
+               {
+                   p.MessageId = $"ID_{m.Counter}";
+                   p.ContentType = MediaTypeNames.Application.Json;
+               }));
+
+            mbb.Consume<PingMessage>(x => x
+                .Path(string.Empty) // default exchange
+                .Queue(queueName)
+                .WithConsumer<PingConsumer>());
+        });
+
+        var messageBus = ServiceProvider.GetRequiredService<IMessageBus>();
+        var consumedMessages = ServiceProvider.GetRequiredService<TestEventCollector<TestEvent>>();
+
+        var ping = new PingMessage { Counter = 42 };
+
+        // act
+        await messageBus.Publish(ping);
+
+        await consumedMessages.WaitUntilArriving();
+
+        // assert
+        var received = consumedMessages.Snapshot().Single();
+        received.Message.Counter.Should().Be(42);
+        received.Message.Value.Should().Be(ping.Value);
+    }
+
+    protected override void SetupServices(ServiceCollection services, IConfigurationRoot configuration)
+    {
+        services.AddSlimMessageBus((mbb) =>
+        {
+            mbb.WithProviderRabbitMQ(cfg =>
+            {
+                cfg.ConnectionString = Secrets.Service.PopulateSecrets(configuration["RabbitMQ:ConnectionString"]);
+
+                cfg.ConnectionFactory.ClientProvidedName = $"MyService_{Environment.MachineName}";
+
+                cfg.UseMessagePropertiesModifier((m, p) =>
+                {
+                    p.ContentType = MediaTypeNames.Application.Json;
+                });
+                cfg.UseQueueDefaults(durable: false);
+                cfg.UseTopologyInitializer((channel, applyDefaultTopology) =>
+                {
+                    // before test clean up
+                    channel.QueueDelete("default-exchange-queue", ifUnused: true, ifEmpty: false);
+
+                    // apply default SMB inferred topology
+                    applyDefaultTopology();
+
+                    // after
+                });
+            });
+            mbb.AddServicesFromAssemblyContaining<PingConsumer>();
+            mbb.AddJsonSerializer();
+            ApplyBusConfiguration(mbb);
+        });
+
+        // Custom error handler
+        services.AddTransient(typeof(IRabbitMqConsumerErrorHandler<>), typeof(CustomRabbitMqConsumerErrorHandler<>));
+
+        services.AddSingleton<TestEventCollector<TestEvent>>();
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/RabbitMqMessageBusSettingsValidationServiceTests.cs
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/RabbitMqMessageBusSettingsValidationServiceTests.cs
@@ -1,0 +1,130 @@
+﻿namespace SlimMessageBus.Host.RabbitMQ.Test;
+using System;
+
+using AwesomeAssertions;
+
+using Xunit;
+
+public class RabbitMqMessageBusSettingsValidationServiceTests
+{
+    internal class TestableRabbitMqValidationService : RabbitMqMessageBusSettingsValidationService
+    {
+        public TestableRabbitMqValidationService(MessageBusSettings settings, RabbitMqMessageBusSettings providerSettings)
+            : base(settings, providerSettings)
+        {
+        }
+
+        // Public wrapper to call the protected method
+        public new void AssertConsumer(ConsumerSettings consumerSettings)
+        {
+            base.AssertConsumer(consumerSettings);
+        }
+    }
+
+    private TestableRabbitMqValidationService CreateService()
+    {
+        var busSettings = new MessageBusSettings();
+        var providerSettings = new RabbitMqMessageBusSettings();
+        return new TestableRabbitMqValidationService(busSettings, providerSettings);
+    }
+
+    [Fact]
+    public void AssertConsumer_ShouldThrowArgumentNullException_WhenConsumerSettingsIsNull()
+    {
+        var service = CreateService();
+
+        service.Invoking(s => s.AssertConsumer(null!))
+               .Should().Throw<ArgumentNullException>()
+               .WithMessage("*consumerSettings*");
+    }
+
+    [Fact]
+    public void AssertConsumer_ShouldThrow_WhenMessageTypeIsNull()
+    {
+        var service = CreateService();
+        var consumerSettings = new ConsumerSettings
+        {
+            ConsumerType = typeof(object),
+            Path = "exchange-name",
+        };
+
+        var expectedMessage = $"Consumer (): The MessageType is not set";
+
+        service.Invoking(s => s.AssertConsumer(consumerSettings))
+               .Should().Throw<ConfigurationMessageBusException>()
+               .WithMessage(expectedMessage);
+    }
+
+    [Fact]
+    public void AssertConsumer_ShouldThrow_WhenConsumerTypeIsNull()
+    {
+        var service = CreateService();
+        var consumerSettings = new ConsumerSettings
+        {
+            MessageType = typeof(object),
+            Path = "exchange-name",
+        };
+
+        var expectedMessage = $"Consumer (Object): The ConsumerType is not set";
+
+        service.Invoking(s => s.AssertConsumer(consumerSettings))
+               .Should().Throw<ConfigurationMessageBusException>()
+               .WithMessage(expectedMessage);
+    }
+
+    [Fact]
+    public void AssertConsumer_ShouldThrow_WhenConsumerMethodIsNull()
+    {
+        var service = CreateService();
+        var consumerSettings = new ConsumerSettings
+        {
+            MessageType = typeof(object),
+            ConsumerType = typeof(object),
+            Path = "exchange-name",
+        };
+
+        var expectedMessage = $"Consumer (Object): The ConsumerMethod is not set";
+
+        service.Invoking(s => s.AssertConsumer(consumerSettings))
+               .Should().Throw<ConfigurationMessageBusException>()
+               .WithMessage(expectedMessage);
+    }
+
+    [Fact]
+    public void AssertConsumer_ShouldThrow_WhenPathIsNull()
+    {
+        var service = CreateService();
+        var consumerSettings = new ConsumerSettings
+        {
+            MessageType = typeof(object),
+            ConsumerType = typeof(object),
+            ConsumerMethod = new ConsumerMethod((q, w, e, r) => { return Task.CompletedTask; }),
+            Path = null,
+        };
+
+        var expectedMessage = $"Consumer (Object): The ExchangeBinding is not set";
+
+        service.Invoking(s => s.AssertConsumer(consumerSettings))
+               .Should().Throw<ConfigurationMessageBusException>()
+               .WithMessage(expectedMessage);
+    }
+
+    [Fact]
+    public void AssertConsumer_ShouldThrow_WhenQueueNameIsNull()
+    {
+        var service = CreateService();
+        var consumerSettings = new ConsumerSettings
+        {
+            MessageType = typeof(object),
+            ConsumerType = typeof(object),
+            ConsumerMethod = new ConsumerMethod((q, w, e, r) => { return Task.CompletedTask; }),
+            Path = "exchange-name"
+        };
+
+        var expectedMessage = $"Consumer (Object): The Queue is not set";
+
+        service.Invoking(s => s.AssertConsumer(consumerSettings))
+                       .Should().Throw<ConfigurationMessageBusException>()
+                       .WithMessage(expectedMessage);
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/RabbitMqTopologyServiceTests.cs
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/RabbitMqTopologyServiceTests.cs
@@ -1,0 +1,79 @@
+﻿namespace SlimMessageBus.Host.RabbitMQ.Test;
+
+using System.Collections.Generic;
+
+using AwesomeAssertions;
+
+using global::RabbitMQ.Client;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using SlimMessageBus.Host;
+using SlimMessageBus.Host.RabbitMQ;
+
+using Xunit;
+
+public class RabbitMqTopologyServiceTests
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly Mock<IModel> _channelMock;
+    private readonly RabbitMqMessageBusSettings _providerSettings;
+
+    public RabbitMqTopologyServiceTests()
+    {
+        _loggerFactory = NullLoggerFactory.Instance;
+        _channelMock = new Mock<IModel>();
+        _providerSettings = new RabbitMqMessageBusSettings();
+    }
+
+    [Fact]
+    public void ProvisionTopology_WithEmptyExchangeName_LogsSkippingExchange()
+    {
+        // Arrange
+        var producer = new ProducerSettings { DefaultPath = "" };
+        var settings = new MessageBusSettings();
+        settings.Producers.Add(producer);
+        settings.Consumers.Add(new ConsumerSettings
+        {
+            Path = "some-queue",
+            MessageType = typeof(string),
+            ConsumerType = typeof(object)
+        });
+
+
+        var service = new RabbitMqTopologyService(_loggerFactory, _channelMock.Object, settings, _providerSettings);
+
+        // Act
+        var result = service.ProvisionTopology();
+
+        // Assert
+        result.Should().BeTrue();
+        _channelMock.Verify(x => x.ExchangeDeclare(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IDictionary<string, object>>()), Times.Never);
+    }
+
+    [Fact]
+    public void ProvisionTopology_WithNonEmptyExchangeName_DeclaresExchange()
+    {
+        // Arrange
+        var producer = new ProducerSettings { DefaultPath = "my-exchange" };
+        var settings = new MessageBusSettings();
+        settings.Producers.Add(producer);
+        settings.Consumers.Add(new ConsumerSettings
+        {
+            Path = "some-queue",
+            MessageType = typeof(string),
+            ConsumerType = typeof(object)
+        });
+
+        var service = new RabbitMqTopologyService(_loggerFactory, _channelMock.Object, settings, _providerSettings);
+
+        // Act
+        var result = service.ProvisionTopology();
+
+        // Assert
+        result.Should().BeTrue();
+        _channelMock.Verify(x => x.ExchangeDeclare("my-exchange", It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<IDictionary<string, object>>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## [Host.RabbitMQ] Improve Validation and Default Exchange Handling

Enhances validation for consumer and producer settings to properly support the **default exchange**.

- ✅ Avoids declaring or binding the default exchange (handled internally by RabbitMQ).  
- ✅ Adds clearer error messages for missing or invalid configuration.  
- ✅ Logs when default exchange operations are intentionally skipped.  

ℹ️ This ensures correct behavior when working with the default exchange (`""`), which is a pre-declared direct exchange that automatically binds queues by their name.