### PR TITLE
[Host.AmazonSQS] NullReferenceException when consuming plain SQS Messages without MessageAttributes

### DIFF
--- a/src/SlimMessageBus.Host.AmazonSQS/Consumer/SqsBaseConsumer.cs
+++ b/src/SlimMessageBus.Host.AmazonSQS/Consumer/SqsBaseConsumer.cs
@@ -169,8 +169,8 @@ abstract internal class SqsBaseConsumer : AbstractConsumer
         else
         {
             messagePayload = message.Body;
-            messageHeaders = message.MessageAttributes
-                .ToDictionary(x => x.Key, x => HeaderSerializer.Deserialize(x.Key, x.Value));
+            messageHeaders = message.MessageAttributes?
+                .ToDictionary(x => x.Key, x => HeaderSerializer.Deserialize(x.Key, x.Value)) ?? new Dictionary<string, object>();
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the SlimMessageBus project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->
<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific transport or plugin: Mention the it shortname in square brackets
  e.g. "[Host.Kafka]", "[Host.AzureServiceBus]" or "[Host.Serialization.Json]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for XYZ" or "Fix wrongly handled exception"
  for a new plugin: "Initial contribution"
Examples:
- "[Host.AzureServiceBus] Add support for sessions"
-->

<!-- DESCRIPTION -->
When consuming plain SQS Messages without message attributes, the nullable `MessageAttributes` are handled gracefully by providing an empty dictionary.
 
Bugfix for: https://github.com/zarusz/SlimMessageBus/issues/441 

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the /docs?
- Did you sign-off your work:
  https://github.com/zarusz/SlimMessageBus/blob/master/CONTRIBUTING.md#sign-your-work
-->

