### PR TITLE
[Host.Serialization.SystemTextJson] Pass actuall message type during produce

### DIFF
--- a/src/Host.Plugin.Properties.xml
+++ b/src/Host.Plugin.Properties.xml
@@ -4,7 +4,7 @@
   <Import Project="Common.NuGet.Properties.xml" />
 
   <PropertyGroup>
-    <Version>3.3.7-rc100</Version>
+    <Version>3.4.0-rc100</Version>
   </PropertyGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Serialization.SystemTextJson/JsonMessageSerializer.cs
+++ b/src/SlimMessageBus.Host.Serialization.SystemTextJson/JsonMessageSerializer.cs
@@ -9,14 +9,17 @@ using System.Text.Json.Serialization;
 /// </summary>
 public class JsonMessageSerializer : IMessageSerializer, IMessageSerializer<string>, IMessageSerializerProvider
 {
+    private readonly bool _useActualTypeOnSerialize;
+
     /// <summary>
     /// <see cref="JsonSerializerOptions"/> options for the JSON serializer. By default adds <see cref="ObjectToInferredTypesConverter"/> converter.
     /// </summary>
     public JsonSerializerOptions Options { get; set; }
 
-    public JsonMessageSerializer(JsonSerializerOptions options = null)
+    public JsonMessageSerializer(JsonSerializerOptions options = null, bool useActualTypeOnSerialize = true)
     {
         Options = options ?? CreateDefaultOptions();
+        _useActualTypeOnSerialize = useActualTypeOnSerialize;
     }
 
     public virtual JsonSerializerOptions CreateDefaultOptions()
@@ -34,7 +37,7 @@ public class JsonMessageSerializer : IMessageSerializer, IMessageSerializer<stri
     #region Implementation of IMessageSerializer
 
     public byte[] Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage)
-        => JsonSerializer.SerializeToUtf8Bytes(message, messageType, Options);
+        => JsonSerializer.SerializeToUtf8Bytes(message, _useActualTypeOnSerialize && message != null ? message.GetType() : messageType, Options);
 
     public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, byte[] payload, object transportMessage)
         => JsonSerializer.Deserialize(payload, messageType, Options)!;
@@ -44,7 +47,7 @@ public class JsonMessageSerializer : IMessageSerializer, IMessageSerializer<stri
     #region Implementation of IMessageSerializer<string>
 
     string IMessageSerializer<string>.Serialize(Type messageType, IDictionary<string, object> headers, object message, object transportMessage)
-        => JsonSerializer.Serialize(message, messageType, Options);
+        => JsonSerializer.Serialize(message, _useActualTypeOnSerialize && message != null ? message.GetType() : messageType, Options);
 
     public object Deserialize(Type messageType, IReadOnlyDictionary<string, object> headers, string payload, object transportMessage)
         => JsonSerializer.Deserialize(payload, messageType, Options)!;

--- a/src/SlimMessageBus.Host.Serialization.SystemTextJson/SerializationBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Serialization.SystemTextJson/SerializationBuilderExtensions.cs
@@ -13,14 +13,16 @@ public static class SerializationBuilderExtensions
     /// Registers the <see cref="IMessageSerializer"/> with implementation as <see cref="JsonMessageSerializer"/>.
     /// </summary>
     /// <param name="builder"></param>
+    /// <param name="options"></param>
+    /// <param name="useActualTypeOnSerialize">Should the actual message type be used during serialization? If false, the producer declared type will be passed (e.g. base type of the actual message). It will make a difference for polymorphic types.</param>
     /// <returns></returns>
-    public static TBuilder AddJsonSerializer<TBuilder>(this TBuilder builder, JsonSerializerOptions options = null)
+    public static TBuilder AddJsonSerializer<TBuilder>(this TBuilder builder, JsonSerializerOptions options = null, bool useActualTypeOnSerialize = true)
         where TBuilder : ISerializationBuilder
     {
         builder.RegisterSerializer<JsonMessageSerializer>(services =>
         {
             // Add the implementation
-            services.TryAddSingleton(svp => new JsonMessageSerializer(options ?? svp.GetService<JsonSerializerOptions>()));
+            services.TryAddSingleton(svp => new JsonMessageSerializer(options ?? svp.GetService<JsonSerializerOptions>(), useActualTypeOnSerialize));
             // Add the serializer as IMessageSerializer<string>
             services.TryAddSingleton(svp => svp.GetRequiredService<JsonMessageSerializer>() as IMessageSerializer<string>);
         });

--- a/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/JsonMessageSerializerTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/JsonMessageSerializerTests.cs
@@ -20,7 +20,7 @@ public class JsonMessageSerializerTests
         // arrange
         var subject = new JsonMessageSerializer();
 
-        // actx
+        // act
         var bytes = subject.Serialize(typeof(object), null, value, null);
         var deserializedValue = subject.Deserialize(typeof(object), null, bytes, null);
 


### PR DESCRIPTION
By default, the serializer uses the `useActualTypeOnSerialize: true` parameter, which ensures that the actual runtime type of the message is used during serialization. This is important for polymorphic message types where you might publish a derived type but declare the producer with a base type.

If this is not the default STJ does only include the base type properties (unlike Newtonsoft.Json). 
