### PR TITLE
Upgrade transport clients and libraries for 3.4.0

### DIFF
--- a/src/Infrastructure/docker-compose.yml
+++ b/src/Infrastructure/docker-compose.yml
@@ -3,29 +3,65 @@ version: "3.4"
 services:
   zookeeper:
     container_name: slim.zookeeper
-    image: wurstmeister/zookeeper
+    image: confluentinc/cp-zookeeper:7.8.0
     ports:
       - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
     networks:
       - slim
 
   kafka:
+    image: confluentinc/cp-kafka:7.8.0
     container_name: slim.kafka
-    image: wurstmeister/kafka:2.13-2.8.1
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_CREATE_TOPICS: "test-ping:2:1,test-echo:2:1,test-echo-resp:2:1"
+      KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://slim.kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_NUM_PARTITIONS: 2
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
     depends_on:
       - zookeeper
     networks:
       - slim
 
+  kafka-init:
+    image: confluentinc/cp-kafka:7.8.0
+    container_name: slim.kafka-init
+    depends_on:
+      - kafka
+    networks:
+      - slim
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      "
+      # Wait for Kafka to be ready
+      echo 'Waiting for Kafka to be ready...'
+      cub kafka-ready -b slim.kafka:29092 1 60
+
+      # Create topics
+      echo 'Creating topics...'
+      kafka-topics --create --if-not-exists --topic test-ping --partitions 2 --replication-factor 1 --bootstrap-server slim.kafka:29092
+      kafka-topics --create --if-not-exists --topic test-echo --partitions 2 --replication-factor 1 --bootstrap-server slim.kafka:29092
+      kafka-topics --create --if-not-exists --topic test-echo-resp --partitions 2 --replication-factor 1 --bootstrap-server slim.kafka:29092
+
+      echo 'Topics created successfully'
+      "
+
   mqtt:
     container_name: slim.mqtt
-    image: eclipse-mosquitto:2.0.18
+    image: eclipse-mosquitto:2.0.22
     ports:
       - "1883:1883" #default mqtt port
       - "9001:9001" #default mqtt port for websockets
@@ -36,18 +72,18 @@ services:
 
   psqldb:
     container_name: slim.psql
-    image: postgres:17.4
+    image: postgres:17.7
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=SecretP@55word
     ports:
       - 5432:5432
     networks:
-      - slim      
+      - slim
 
   rabbitmq:
     container_name: slim.rabbitmq
-    image: rabbitmq:3.12.14-management-alpine
+    image: rabbitmq:4.2.3-management-alpine
     ports:
       - 5672:5672
       - 15672:15672 # user/pass: guest/guest
@@ -56,7 +92,7 @@ services:
 
   redis:
     container_name: slim.redis
-    image: redis:7.2.5
+    image: redis:8.4
     ports:
       - 6379:6379
     networks:
@@ -64,7 +100,7 @@ services:
 
   sqldb:
     container_name: slim.sql
-    image: mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
+    image: mcr.microsoft.com/mssql/server:2022-CU21-ubuntu-22.04
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=SuperSecretP@55word
@@ -75,7 +111,7 @@ services:
 
   storage:
     container_name: slim.storage
-    image: mcr.microsoft.com/azure-storage/azurite:3.31.0
+    image: mcr.microsoft.com/azure-storage/azurite:3.33.0
     command: "azurite --blobHost 0.0.0.0 --blobPort 11000 --queueHost 0.0.0.0 --queuePort 11001 --tableHost 0.0.0.0 --tablePort 11002 --location /data"
     environment:
       - AZURITE_ACCOUNTS=devstoreaccount1:Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;
@@ -88,7 +124,7 @@ services:
 
   nats:
     container_name: slim.nats
-    image: nats:2.10
+    image: nats:2.12.4
     ports:
       - 4222:4222
     networks:

--- a/src/Samples/Sample.AsyncApi.Service/Sample.AsyncApi.Service.csproj
+++ b/src/Samples/Sample.AsyncApi.Service/Sample.AsyncApi.Service.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
-    <PackageReference Include="NSwag.AspNetCore" Version="14.3.0" />
+    <PackageReference Include="NSwag.AspNetCore" Version="14.6.3" />
     <ProjectReference Include="..\..\SlimMessageBus.Host.AsyncApi\SlimMessageBus.Host.AsyncApi.csproj" />
     <ProjectReference Include="..\..\SlimMessageBus.Host.AzureServiceBus\SlimMessageBus.Host.AzureServiceBus.csproj" />
     <ProjectReference Include="..\..\SlimMessageBus.Host.Kafka\SlimMessageBus.Host.Kafka.csproj" />

--- a/src/Samples/Sample.DomainEvents.WebApi/Sample.DomainEvents.WebApi.csproj
+++ b/src/Samples/Sample.DomainEvents.WebApi/Sample.DomainEvents.WebApi.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
   </ItemGroup>
 

--- a/src/Samples/Sample.Nats.WebApi/Sample.Nats.WebApi.csproj
+++ b/src/Samples/Sample.Nats.WebApi/Sample.Nats.WebApi.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/Sample.OutboxWebApi/Sample.OutboxWebApi.csproj
+++ b/src/Samples/Sample.OutboxWebApi/Sample.OutboxWebApi.csproj
@@ -14,7 +14,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sample.ValidatingWebApi/Sample.ValidatingWebApi.csproj
+++ b/src/Samples/Sample.ValidatingWebApi/Sample.ValidatingWebApi.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.AmazonSQS/SlimMessageBus.Host.AmazonSQS.csproj
+++ b/src/SlimMessageBus.Host.AmazonSQS/SlimMessageBus.Host.AmazonSQS.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.6" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.1.6" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.1.8" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.9" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.2.16" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.AsyncApi/SlimMessageBus.Host.AsyncApi.csproj
+++ b/src/SlimMessageBus.Host.AsyncApi/SlimMessageBus.Host.AsyncApi.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Namotion.Reflection" Version="3.3.0" />
+    <PackageReference Include="Namotion.Reflection" Version="3.4.3" />
     <PackageReference Include="Saunter" Version="0.13.0" />
   </ItemGroup>
 

--- a/src/SlimMessageBus.Host.AzureEventHub/SlimMessageBus.Host.AzureEventHub.csproj
+++ b/src/SlimMessageBus.Host.AzureEventHub/SlimMessageBus.Host.AzureEventHub.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.11.6" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.AzureServiceBus/SlimMessageBus.Host.AzureServiceBus.csproj
+++ b/src/SlimMessageBus.Host.AzureServiceBus/SlimMessageBus.Host.AzureServiceBus.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.4" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
+++ b/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
@@ -6,7 +6,7 @@
     <Description>Core configuration interfaces of SlimMessageBus</Description>
     <PackageTags>SlimMessageBus</PackageTags>
     <RootNamespace>SlimMessageBus.Host</RootNamespace>
-    <Version>3.3.7-rc100</Version>
+    <Version>3.4.0-rc100</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.FluentValidation/SlimMessageBus.Host.FluentValidation.csproj
+++ b/src/SlimMessageBus.Host.FluentValidation/SlimMessageBus.Host.FluentValidation.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.11.0" />
+    <PackageReference Include="FluentValidation" Version="11.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Kafka/SlimMessageBus.Host.Kafka.csproj
+++ b/src/SlimMessageBus.Host.Kafka/SlimMessageBus.Host.Kafka.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.9.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Nats/SlimMessageBus.Host.Nats.csproj
+++ b/src/SlimMessageBus.Host.Nats/SlimMessageBus.Host.Nats.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NATS.Net" Version="2.5.12" />
+    <PackageReference Include="NATS.Net" Version="2.7.1" />
   </ItemGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Redis/SlimMessageBus.Host.Redis.csproj
+++ b/src/SlimMessageBus.Host.Redis/SlimMessageBus.Host.Redis.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.8.31" />
+    <PackageReference Include="StackExchange.Redis" Version="2.10.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Serialization.Avro/SlimMessageBus.Host.Serialization.Avro.csproj
+++ b/src/SlimMessageBus.Host.Serialization.Avro/SlimMessageBus.Host.Serialization.Avro.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.Avro" Version="1.12.0" />
+    <PackageReference Include="Apache.Avro" Version="1.12.1" />
     
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />

--- a/src/SlimMessageBus.Host.Serialization.GoogleProtobuf/SlimMessageBus.Host.Serialization.GoogleProtobuf.csproj
+++ b/src/SlimMessageBus.Host.Serialization.GoogleProtobuf/SlimMessageBus.Host.Serialization.GoogleProtobuf.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.30.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.33.5" />
     
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />

--- a/src/SlimMessageBus.Host.Serialization.Json/SlimMessageBus.Host.Serialization.Json.csproj
+++ b/src/SlimMessageBus.Host.Serialization.Json/SlimMessageBus.Host.Serialization.Json.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" Condition="'$(TargetFramework)' == 'net9.0'" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Serialization.SystemTextJson/SlimMessageBus.Host.Serialization.SystemTextJson.csproj
+++ b/src/SlimMessageBus.Host.Serialization.SystemTextJson/SlimMessageBus.Host.Serialization.SystemTextJson.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="6.0.10" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Text.Json" Version="6.0.10" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="System.Text.Json" Version="9.0.3" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="System.Text.Json" Version="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Sql.Common/SlimMessageBus.Host.Sql.Common.csproj
+++ b/src/SlimMessageBus.Host.Sql.Common/SlimMessageBus.Host.Sql.Common.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
   </ItemGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Sql.Common/SqlHelper.cs
+++ b/src/SlimMessageBus.Host.Sql.Common/SqlHelper.cs
@@ -64,16 +64,3 @@ public static partial class SqlHelper
 
     #endregion
 }
-
-#if NETSTANDARD2_0
-
-partial class SqlHelper
-{
-    private static partial void LogSqlError(ILogger logger, int sqlRetryCount, int sqlRetryNumber)
-        => logger.LogInformation("SQL error encountered. Will begin attempt number {SqlRetryNumber} of {SqlRetryCount} max...", sqlRetryNumber, sqlRetryCount);
-
-    private static partial void LogWillRetry(ILogger logger, int sqlErrorCode, SqlException e)
-        => logger.LogDebug(e, "SQL error occurred {SqlErrorCode}. Will retry operation", sqlErrorCode);
-}
-
-#endif

--- a/src/Tests/Host.Test.Properties.xml
+++ b/src/Tests/Host.Test.Properties.xml
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.1.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/Tests/SecretStore.Test/SecretStore.Test.csproj
+++ b/src/Tests/SecretStore.Test/SecretStore.Test.csproj
@@ -6,4 +6,8 @@
     <ProjectReference Include="..\..\Tools\SecretStore\SecretStore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.AmazonSQS.Test/SlimMessageBus.Host.AmazonSQS.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.AmazonSQS.Test/SlimMessageBus.Host.AmazonSQS.Test.csproj
@@ -18,4 +18,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.AspNetCore.Test/SlimMessageBus.Host.AspNetCore.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.AspNetCore.Test/SlimMessageBus.Host.AspNetCore.Test.csproj
@@ -11,4 +11,8 @@
     <ProjectReference Include="..\..\SlimMessageBus.Host.AspNetCore\SlimMessageBus.Host.AspNetCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.AsyncApi.Test/SlimMessageBus.Host.AsyncApi.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.AsyncApi.Test/SlimMessageBus.Host.AsyncApi.Test.csproj
@@ -7,4 +7,8 @@
     <ProjectReference Include="..\SlimMessageBus.Host.Test.Common\SlimMessageBus.Host.Test.Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.AzureEventHub.Test/SlimMessageBus.Host.AzureEventHub.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.AzureEventHub.Test/SlimMessageBus.Host.AzureEventHub.Test.csproj
@@ -20,4 +20,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.AzureServiceBus.Test/SlimMessageBus.Host.AzureServiceBus.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.AzureServiceBus.Test/SlimMessageBus.Host.AzureServiceBus.Test.csproj
@@ -19,4 +19,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Benchmark/SlimMessageBus.Host.Benchmark.csproj
+++ b/src/Tests/SlimMessageBus.Host.Benchmark/SlimMessageBus.Host.Benchmark.csproj
@@ -8,11 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\SlimMessageBus.Host\SlimMessageBus.Host.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/SlimMessageBus.Host.CircuitBreaker.HealthCheck.Test/SlimMessageBus.Host.CircuitBreaker.HealthCheck.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.CircuitBreaker.HealthCheck.Test/SlimMessageBus.Host.CircuitBreaker.HealthCheck.Test.csproj
@@ -17,4 +17,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.CircuitBreaker.Test/SlimMessageBus.Host.CircuitBreaker.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.CircuitBreaker.Test/SlimMessageBus.Host.CircuitBreaker.Test.csproj
@@ -17,4 +17,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Configuration.Test/SlimMessageBus.Host.Configuration.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Configuration.Test/SlimMessageBus.Host.Configuration.Test.csproj
@@ -8,4 +8,8 @@
     <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.Json\SlimMessageBus.Host.Serialization.Json.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.FluentValidation.Test/SlimMessageBus.Host.FluentValidation.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.FluentValidation.Test/SlimMessageBus.Host.FluentValidation.Test.csproj
@@ -8,4 +8,8 @@
     <ProjectReference Include="..\..\SlimMessageBus.Host.FluentValidation\SlimMessageBus.Host.FluentValidation.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Integration.Test/SlimMessageBus.Host.Integration.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Integration.Test/SlimMessageBus.Host.Integration.Test.csproj
@@ -17,4 +17,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/SlimMessageBus.Host.Kafka.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/SlimMessageBus.Host.Kafka.Test.csproj
@@ -18,6 +18,10 @@
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>  
 
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Memory.Benchmark/SlimMessageBus.Host.Memory.Benchmark.csproj
+++ b/src/Tests/SlimMessageBus.Host.Memory.Benchmark/SlimMessageBus.Host.Memory.Benchmark.csproj
@@ -8,12 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\SlimMessageBus.Host.Memory\SlimMessageBus.Host.Memory.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Memory.Test/SlimMessageBus.Host.Memory.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Memory.Test/SlimMessageBus.Host.Memory.Test.csproj
@@ -15,4 +15,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Mqtt.Test/SlimMessageBus.Host.Mqtt.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Mqtt.Test/SlimMessageBus.Host.Mqtt.Test.csproj
@@ -15,4 +15,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Nats.Test/SlimMessageBus.Host.Nats.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Nats.Test/SlimMessageBus.Host.Nats.Test.csproj
@@ -14,5 +14,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
   
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test.csproj
@@ -8,9 +8,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Testcontainers.Kafka" Version="4.3.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.3.0" />
-    <PackageReference Include="Testcontainers.RabbitMq" Version="4.3.0" />
+    <PackageReference Include="Testcontainers.Kafka" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.RabbitMq" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +30,10 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.Test/SlimMessageBus.Host.Outbox.PostgreSql.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.Test/SlimMessageBus.Host.Outbox.PostgreSql.Test.csproj
@@ -8,7 +8,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.3.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Outbox.Sql.DbContext.Test/BaseOutboxIntegrationTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.Sql.DbContext.Test/BaseOutboxIntegrationTest.cs
@@ -1,5 +1,6 @@
 ﻿namespace SlimMessageBus.Host.Outbox.Sql.DbContext.Test;
 
+using System.Diagnostics;
 using SlimMessageBus.Host.Outbox.Sql.DbContext.Test.DataAccess;
 
 public abstract class BaseOutboxIntegrationTest<T>(ITestOutputHelper output) : BaseIntegrationTest<T>(output)
@@ -17,5 +18,82 @@ public abstract class BaseOutboxIntegrationTest<T>(ITestOutputHelper output) : B
         {
             await ((IAsyncDisposable)scope).DisposeAsync();
         }
+    }
+
+    /// <summary>
+    /// Wait for the outbox to be drained (no pending messages).
+    /// </summary>
+    /// <param name="timeoutSeconds">Maximum time to wait in seconds</param>
+    protected async Task WaitForOutboxToBeDrained(int timeoutSeconds = 10)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var lastPendingCount = int.MaxValue;
+        var stuckCount = 0;
+        const int maxStuckIterations = 5; // If count doesn't change after 5 checks, exit early
+        
+        while (stopwatch.Elapsed.TotalSeconds < timeoutSeconds)
+        {
+            var scope = ServiceProvider!.CreateScope();
+            try
+            {
+                var context = scope.ServiceProvider.GetRequiredService<CustomerContext>();
+                
+                // Query the Outbox table to count pending messages
+                // DeliveryComplete = 0 means the message hasn't been delivered yet
+                var connection = context.Database.GetDbConnection();
+                var wasOpen = connection.State == System.Data.ConnectionState.Open;
+                if (!wasOpen)
+                {
+                    await connection.OpenAsync();
+                }
+
+                try
+                {
+                    using var command = connection.CreateCommand();
+                    command.CommandText = $"SELECT COUNT(*) FROM [{CustomerContext.Schema}].[Outbox] WHERE [DeliveryComplete] = 0 AND [DeliveryAborted] = 0";
+                    var result = await command.ExecuteScalarAsync();
+                    var pendingCount = Convert.ToInt32(result);
+                    
+                    if (pendingCount == 0)
+                    {
+                        Logger.LogInformation("Outbox is drained (0 pending messages) after {Elapsed}", stopwatch.Elapsed);
+                        return;
+                    }
+                    
+                    // Track if count is stuck (not changing)
+                    if (pendingCount == lastPendingCount)
+                    {
+                        stuckCount++;
+                        if (stuckCount >= maxStuckIterations)
+                        {
+                            Logger.LogWarning("Outbox pending count stuck at {PendingCount} for {StuckIterations} iterations after {Elapsed}, exiting early", 
+                                pendingCount, stuckCount, stopwatch.Elapsed);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        stuckCount = 0;
+                        Logger.LogInformation("Outbox has {PendingCount} pending messages after {Elapsed}", pendingCount, stopwatch.Elapsed);
+                        lastPendingCount = pendingCount;
+                    }
+                }
+                finally
+                {
+                    if (!wasOpen)
+                    {
+                        await connection.CloseAsync();
+                    }
+                }
+                
+                await Task.Delay(250);
+            }
+            finally
+            {
+                await ((IAsyncDisposable)scope).DisposeAsync();
+            }
+        }
+        
+        Logger.LogWarning("Timeout waiting for outbox to drain after {Elapsed}", stopwatch.Elapsed);
     }
 }

--- a/src/Tests/SlimMessageBus.Host.Outbox.Sql.DbContext.Test/SlimMessageBus.Host.Outbox.Sql.DbContext.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Outbox.Sql.DbContext.Test/SlimMessageBus.Host.Outbox.Sql.DbContext.Test.csproj
@@ -32,4 +32,8 @@
     <Folder Include="Migrations\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Outbox.Sql.Test/SlimMessageBus.Host.Outbox.Sql.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Outbox.Sql.Test/SlimMessageBus.Host.Outbox.Sql.Test.csproj
@@ -8,7 +8,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Testcontainers.MsSql" Version="4.3.0" />
+	  <PackageReference Include="Testcontainers.MsSql" Version="4.10.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
 	</ItemGroup>
 
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Outbox.Test/SlimMessageBus.Host.Outbox.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Outbox.Test/SlimMessageBus.Host.Outbox.Test.csproj
@@ -7,4 +7,8 @@
     <ProjectReference Include="..\..\SlimMessageBus.Host.Outbox\SlimMessageBus.Host.Outbox.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/SlimMessageBus.Host.RabbitMQ.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/SlimMessageBus.Host.RabbitMQ.Test.csproj
@@ -19,4 +19,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Redis.Test/SlimMessageBus.Host.Redis.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Redis.Test/SlimMessageBus.Host.Redis.Test.csproj
@@ -15,4 +15,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/SlimMessageBus.Host.Serialization.Avro.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/SlimMessageBus.Host.Serialization.Avro.Test.csproj
@@ -14,4 +14,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+   <ItemGroup>
+     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+   </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Serialization.Benchmark/SlimMessageBus.Host.Serialization.Benchmark.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Benchmark/SlimMessageBus.Host.Serialization.Benchmark.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 
   <ItemGroup>
@@ -16,6 +16,10 @@
     <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.Avro\SlimMessageBus.Host.Serialization.Avro.csproj" />
     <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.Json\SlimMessageBus.Host.Serialization.Json.csproj" />
     <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.SystemTextJson\SlimMessageBus.Host.Serialization.SystemTextJson.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test.csproj
@@ -7,12 +7,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.70.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.71.0">
+    <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.76.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Grpc.Net.Client" Version="2.70.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SlimMessageBus.Host.Serialization.Hybrid.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SlimMessageBus.Host.Serialization.Hybrid.Test.csproj
@@ -11,4 +11,8 @@
     <ProjectReference Include="..\..\SlimMessageBus.Host\SlimMessageBus.Host.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Serialization.Json.Test/SlimMessageBus.Host.Serialization.Json.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Json.Test/SlimMessageBus.Host.Serialization.Json.Test.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.Json\SlimMessageBus.Host.Serialization.Json.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/SlimMessageBus.Host.Serialization.SystemTextJson.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/SlimMessageBus.Host.Serialization.SystemTextJson.Test.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\..\SlimMessageBus.Host.Serialization.SystemTextJson\SlimMessageBus.Host.Serialization.SystemTextJson.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Host.Test.Common/SlimMessageBus.Host.Test.Common.csproj
+++ b/src/Tests/SlimMessageBus.Host.Test.Common/SlimMessageBus.Host.Test.Common.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.19" />
   </ItemGroup>
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tests/SlimMessageBus.Host.Test/SlimMessageBus.Host.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Test/SlimMessageBus.Host.Test.csproj
@@ -15,4 +15,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tests/SlimMessageBus.Test/SlimMessageBus.Test.csproj
+++ b/src/Tests/SlimMessageBus.Test/SlimMessageBus.Test.csproj
@@ -7,4 +7,8 @@
     <ProjectReference Include="..\..\Tools\SecretStore\SecretStore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Upgraded most of the non-breaking change transport clients (RabbitMq #340 and MQTT will be part of another change).
- Upgraded the docker-compose to run all latest transport servers
- A bit of changes to reduce test flakyness