### PR TITLE
[Host.Nats] Queues support via QueueGroup

### DIFF
--- a/docs/provider_nats.md
+++ b/docs/provider_nats.md
@@ -24,11 +24,18 @@ builder.Services.AddSlimMessageBus(mbb =>
         cfg.AuthOpts = NatsAuthOpts.Default;
     });
 
+    // pub/sub
     mbb
         .Produce<PingMessage>(x => x.DefaultTopic(topic))
         .Consume<PingMessage>(x => x.Topic(topic).Instances(1));
 
+    // queue
+    mbb
+        .Produce<QueueMessage>(x => x.DefaultQueue(topic))
+        .Consume<QueueMessage>(x => x.Queue(topic).Instances(1));
+
     mbb.AddServicesFromAssemblyContaining<PingConsumer>();
+    mbb.AddServicesFromAssemblyContaining<QueueMessage>();
     mbb.AddJsonSerializer();
 });
 ```

--- a/src/Samples/Sample.Nats.WebApi/Consumers.cs
+++ b/src/Samples/Sample.Nats.WebApi/Consumers.cs
@@ -12,3 +12,14 @@ public class PingConsumer(ILogger<PingConsumer> logger) : IConsumer<PingMessage>
         return Task.CompletedTask;
     }
 }
+
+public class QueueConsumer(ILogger<QueueConsumer> logger) : IConsumer<QueueMessage>, IConsumerWithContext
+{
+    public IConsumerContext? Context { get; set; }
+
+    public Task OnHandle(QueueMessage message, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Got message {Counter} on queue {Path}", message.Counter, Context?.Path);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Samples/Sample.Nats.WebApi/Messages.cs
+++ b/src/Samples/Sample.Nats.WebApi/Messages.cs
@@ -1,4 +1,5 @@
 namespace Sample.Nats.WebApi;
 
 public record PingMessage(int Counter, Guid Value);
+public record QueueMessage(int Counter, Guid Value);
 

--- a/src/SlimMessageBus.Host.Nats/Config/NatsConsumerBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Nats/Config/NatsConsumerBuilderExtensions.cs
@@ -1,0 +1,24 @@
+namespace SlimMessageBus.Host.Nats;
+
+public static class NatsConsumerBuilderExtensions
+{
+    public static ConsumerBuilder<T> Queue<T>(this ConsumerBuilder<T> natsBuilder, string natsQueue)
+    {
+        if (natsBuilder is null) throw new ArgumentNullException(nameof(natsBuilder));
+        if (natsQueue is null) throw new ArgumentNullException(nameof(natsQueue));
+
+        natsBuilder.Path(natsQueue);
+        natsBuilder.ConsumerSettings.PathKind = PathKind.Queue;
+        return natsBuilder;
+    }
+
+    public static ConsumerBuilder<T> Queue<T>(this ConsumerBuilder<T> natsBuilder, string natsQueue, Action<ConsumerBuilder<T>> natsTopicConfig)
+    {
+        if (natsBuilder is null) throw new ArgumentNullException(nameof(natsBuilder));
+        if (natsTopicConfig is null) throw new ArgumentNullException(nameof(natsTopicConfig));
+
+        var b = natsBuilder.Queue(natsQueue);
+        natsTopicConfig(b);
+        return b;
+    }
+}

--- a/src/SlimMessageBus.Host.Nats/Config/NatsHandlerBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Nats/Config/NatsHandlerBuilderExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace SlimMessageBus.Host.Nats;
+
+public static class NatsHandlerBuilderExtensions
+{
+    /// <summary>
+    /// Configure queue name that incoming requests (<see cref="TRequest"/>) are expected on.
+    /// </summary>
+    /// <param name="natsBuilder"></param>
+    /// <param name="natsQueue">Queue name</param>
+    /// <returns></returns>
+    public static HandlerBuilder<TRequest, TResponse> Queue<TRequest, TResponse>(this HandlerBuilder<TRequest, TResponse> natsBuilder, string natsQueue)
+    {
+        if (natsBuilder is null) throw new ArgumentNullException(nameof(natsBuilder));
+        if (natsQueue is null) throw new ArgumentNullException(nameof(natsQueue));
+
+        natsBuilder.Path(natsQueue);
+        natsBuilder.ConsumerSettings.PathKind = PathKind.Queue;
+        return natsBuilder;
+    }
+}

--- a/src/SlimMessageBus.Host.Nats/Config/NatsProducerBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Nats/Config/NatsProducerBuilderExtensions.cs
@@ -1,0 +1,42 @@
+namespace SlimMessageBus.Host.Nats;
+
+public static class NatsProducerBuilderExtensions
+{
+    public static ProducerBuilder<T> DefaultQueue<T>(this ProducerBuilder<T> natsProducerBuilder, string natsQueue)
+    {
+        if (natsProducerBuilder is null) throw new ArgumentNullException(nameof(natsProducerBuilder));
+        if (natsQueue is null) throw new ArgumentNullException(nameof(natsQueue));
+
+        natsProducerBuilder.DefaultTopic(natsQueue);
+        natsProducerBuilder.ToQueue();
+        return natsProducerBuilder;
+    }
+
+    /// <summary>
+    /// The topic parameter name in <see cref="IPublishBus.Publish{TMessage}"/> should be treated as a topic name
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="natsProducerBuilder"></param>
+    /// <returns></returns>
+    public static ProducerBuilder<T> ToTopic<T>(this ProducerBuilder<T> natsProducerBuilder)
+    {
+        if (natsProducerBuilder is null) throw new ArgumentNullException(nameof(natsProducerBuilder));
+
+        natsProducerBuilder.Settings.PathKind = PathKind.Topic;
+        return natsProducerBuilder;
+    }
+
+    /// <summary>
+    /// The topic parameter name in <see cref="IPublishBus.Publish{TMessage}"/> should be treated as a queue group name
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="natsProducerBuilder"></param>
+    /// <returns></returns>
+    public static ProducerBuilder<T> ToQueue<T>(this ProducerBuilder<T> natsProducerBuilder)
+    {
+        if (natsProducerBuilder is null) throw new ArgumentNullException(nameof(natsProducerBuilder));
+
+        natsProducerBuilder.Settings.PathKind = PathKind.Queue;
+        return natsProducerBuilder;
+    }
+}

--- a/src/SlimMessageBus.Host.Nats/Config/NatsRequestResponseBuilderExtensions.cs
+++ b/src/SlimMessageBus.Host.Nats/Config/NatsRequestResponseBuilderExtensions.cs
@@ -1,0 +1,25 @@
+﻿namespace SlimMessageBus.Host.Nats;
+
+public static class NatsRequestResponseBuilderExtensions
+{
+    public static RequestResponseBuilder ReplyToQueue(this RequestResponseBuilder natsBuilder, string natsQueue)
+    {
+        if (natsBuilder is null) throw new ArgumentNullException(nameof(natsBuilder));
+        if (natsQueue is null) throw new ArgumentNullException(nameof(natsQueue));
+
+        natsBuilder.Settings.Path = natsQueue;
+        natsBuilder.Settings.PathKind = PathKind.Queue;
+        return natsBuilder;
+    }
+
+    public static RequestResponseBuilder ReplyToQueue(this RequestResponseBuilder natsBuilder, string natsQueue, Action<RequestResponseBuilder> natsBuilderConfig)
+    {
+        if (natsBuilder is null) throw new ArgumentNullException(nameof(natsBuilder));
+        if (natsQueue is null) throw new ArgumentNullException(nameof(natsQueue));
+        if (natsBuilderConfig is null) throw new ArgumentNullException(nameof(natsBuilderConfig));
+
+        var b = natsBuilder.ReplyToQueue(natsQueue);
+        natsBuilderConfig(b);
+        return b;
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.Nats.Test/Config/NatsConsumerBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Nats.Test/Config/NatsConsumerBuilderExtensionsTests.cs
@@ -1,0 +1,104 @@
+namespace SlimMessageBus.Host.Nats.Test.Config;
+
+
+public class NatsConsumerBuilderExtensionsTests
+{
+    private class TestMessage { }
+
+    private readonly MessageBusSettings _settings;
+    private readonly ConsumerBuilder<TestMessage> _consumerBuilder;
+
+    public NatsConsumerBuilderExtensionsTests()
+    {
+        _settings = new MessageBusSettings();
+        _consumerBuilder = new ConsumerBuilder<TestMessage>(_settings);
+    }
+
+    #region Queue Tests
+
+    [Fact]
+    public void When_Queue_Given_NullBuilder_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => NatsConsumerBuilderExtensions.Queue<TestMessage>(null, "test-queue");
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsBuilder");
+    }
+
+    [Fact]
+    public void When_Queue_Given_NullQueueName_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => _consumerBuilder.Queue(null);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsQueue");
+    }
+
+    [Fact]
+    public void When_Queue_Given_ValidParameters_Then_SetsPathAndPathKind()
+    {
+        // Arrange
+        var queueName = "test-queue";
+
+        // Act
+        var result = _consumerBuilder.Queue(queueName);
+
+        // Assert
+        result.Should().BeSameAs(_consumerBuilder);
+        _consumerBuilder.ConsumerSettings.Path.Should().Be(queueName);
+        _consumerBuilder.ConsumerSettings.PathKind.Should().Be(PathKind.Queue);
+    }
+
+    #endregion
+
+    #region Queue with topicConfig Tests
+
+    [Fact]
+    public void When_Queue_TopicConfig_Given_NullBuilder_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => NatsConsumerBuilderExtensions.Queue<TestMessage>(null, "test-queue", (_) => { });
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsBuilder");
+    }
+
+    [Fact]
+    public void When_Queue_TopicConfig_Given_NullQueueName_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => _consumerBuilder.Queue(null, (_) => { });
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsQueue");
+    }
+
+    [Fact]
+    public void When_Queue_TopicConfig_Given_NullTopicConfig_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => _consumerBuilder.Queue("test-queue", null);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsTopicConfig");
+    }
+
+    [Fact]
+    public void When_Queue_TopicConfig_Given_ValidParameters_Then_SetsPathAndPathKind()
+    {
+        // Arrange
+        var queueName = "test-queue";
+
+        // Act
+        var result = _consumerBuilder.Queue(queueName, (_) => { });
+
+        // Assert
+        result.Should().BeSameAs(_consumerBuilder);
+        _consumerBuilder.ConsumerSettings.Path.Should().Be(queueName);
+        _consumerBuilder.ConsumerSettings.PathKind.Should().Be(PathKind.Queue);
+    }
+
+    #endregion
+}

--- a/src/Tests/SlimMessageBus.Host.Nats.Test/Config/NatsHandlerBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Nats.Test/Config/NatsHandlerBuilderExtensionsTests.cs
@@ -1,0 +1,58 @@
+namespace SlimMessageBus.Host.Nats.Test.Config;
+
+using SlimMessageBus.Host.Nats;
+
+public class NatsHandlerBuilderExtensionsTests
+{
+    public interface ISomeMessageMarkerInterface { }
+    public record SomeRequest : IRequest<SomeResponse>, ISomeMessageMarkerInterface;
+    public record SomeResponse;
+
+    private readonly MessageBusSettings _messageBusSettings;
+    private readonly HandlerBuilder<SomeRequest, SomeResponse> _handlerBuilder;
+
+    public NatsHandlerBuilderExtensionsTests()
+    {
+        _messageBusSettings = new MessageBusSettings();
+        _handlerBuilder = new HandlerBuilder<SomeRequest, SomeResponse>(_messageBusSettings);
+    }
+
+    #region Queue Tests
+
+    [Fact]
+    public void When_Queue_Given_NullBuilder_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => NatsHandlerBuilderExtensions.Queue<SomeRequest, SomeResponse>(null, "test-queue");
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsBuilder");
+    }
+
+    [Fact]
+    public void When_Queue_Given_NullQueueName_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => _handlerBuilder.Queue(null);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsQueue");
+    }
+
+    [Fact]
+    public void When_Queue_Given_ValidParameters_Then_SetsDefaultPathAndQueuePathKind()
+    {
+        // Arrange
+        var queueName = "test-queue";
+
+        // Act
+        var result = _handlerBuilder.Queue(queueName);
+
+        // Assert
+        result.Should().BeSameAs(_handlerBuilder);
+        _handlerBuilder.Settings.Consumers.First().Path.Should().Be(queueName);
+        _handlerBuilder.Settings.Consumers.First().PathKind.Should().Be(PathKind.Queue);
+    }
+
+    #endregion
+}

--- a/src/Tests/SlimMessageBus.Host.Nats.Test/Config/NatsProducerBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Nats.Test/Config/NatsProducerBuilderExtensionsTests.cs
@@ -1,0 +1,114 @@
+namespace SlimMessageBus.Host.Nats.Test.Config;
+
+using SlimMessageBus.Host.Nats;
+
+public class NatsProducerBuilderExtensionsTests
+{
+    private class TestMessage { }
+
+    private readonly MessageBusSettings _settings;
+    private readonly ProducerBuilder<TestMessage> _producerBuilder;
+
+    public NatsProducerBuilderExtensionsTests()
+    {
+        _settings = new MessageBusSettings();
+        var producerSettings = new ProducerSettings { MessageType = typeof(TestMessage) };
+        _settings.Producers.Add(producerSettings);
+        _producerBuilder = new ProducerBuilder<TestMessage>(producerSettings);
+    }
+
+    #region DefaultQueue Tests
+
+    [Fact]
+    public void When_DefaultQueue_Given_NullBuilder_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => NatsProducerBuilderExtensions.DefaultQueue<TestMessage>(null, "test-queue");
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsProducerBuilder");
+    }
+
+    [Fact]
+    public void When_DefaultQueue_Given_NullQueueName_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => _producerBuilder.DefaultQueue(null);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsQueue");
+    }
+
+    [Fact]
+    public void When_DefaultQueue_Given_ValidParameters_Then_SetsDefaultPathAndQueuePathKind()
+    {
+        // Arrange
+        var queueName = "test-queue";
+
+        // Act
+        var result = _producerBuilder.DefaultQueue(queueName);
+
+        // Assert
+        result.Should().BeSameAs(_producerBuilder);
+        _producerBuilder.Settings.DefaultPath.Should().Be(queueName);
+        _producerBuilder.Settings.PathKind.Should().Be(PathKind.Queue);
+    }
+
+    #endregion
+
+    #region ToTopic Tests
+
+    [Fact]
+    public void When_ToTopic_Given_NullBuilder_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => NatsProducerBuilderExtensions.ToTopic<TestMessage>(null);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsProducerBuilder");
+    }
+
+    [Fact]
+    public void When_ToTopic_Given_ValidBuilder_Then_SetsQueuePathKind()
+    {
+        // Arrange
+        _producerBuilder.Settings.PathKind = PathKind.Queue; // Set to Queue first to test change
+
+        // Act
+        var result = _producerBuilder.ToTopic();
+
+        // Assert
+        result.Should().BeSameAs(_producerBuilder);
+        _producerBuilder.Settings.PathKind.Should().Be(PathKind.Topic);
+    }
+
+    #endregion
+
+    #region ToQueue Tests
+
+    [Fact]
+    public void When_ToQueue_Given_NullBuilder_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => NatsProducerBuilderExtensions.ToQueue<TestMessage>(null);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsProducerBuilder");
+    }
+
+    [Fact]
+    public void When_ToQueue_Given_ValidBuilder_Then_SetsQueuePathKind()
+    {
+        // Arrange
+        _producerBuilder.Settings.PathKind = PathKind.Topic; // Set to Topic first to test change
+
+        // Act
+        var result = _producerBuilder.ToQueue();
+
+        // Assert
+        result.Should().BeSameAs(_producerBuilder);
+        _producerBuilder.Settings.PathKind.Should().Be(PathKind.Queue);
+    }
+
+    #endregion
+}

--- a/src/Tests/SlimMessageBus.Host.Nats.Test/Config/NatsRequestResponseBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Nats.Test/Config/NatsRequestResponseBuilderExtensionsTests.cs
@@ -1,0 +1,103 @@
+namespace SlimMessageBus.Host.Nats.Test.Config;
+
+using SlimMessageBus.Host.Nats;
+
+public class NatsRequestResponseBuilderExtensionsTests
+{
+    private readonly RequestResponseSettings _settings;
+    private readonly RequestResponseBuilder _requestResponseBuilder;
+
+    public NatsRequestResponseBuilderExtensionsTests()
+    {
+        _settings = new RequestResponseSettings();
+        _requestResponseBuilder = new RequestResponseBuilder(_settings);
+    }
+
+    #region ReplyToQueue Tests
+
+    [Fact]
+    public void When_ReplyToQueue_Given_NullBuilder_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => NatsRequestResponseBuilderExtensions.ReplyToQueue(null, "test-queue");
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsBuilder");
+    }
+
+    [Fact]
+    public void When_ReplyToQueue_Given_NullQueueName_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => _requestResponseBuilder.ReplyToQueue(null);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsQueue");
+    }
+
+    [Fact]
+    public void When_ReplyToQueue_Given_ValidParameters_Then_SetsDefaultPathAndQueuePathKind()
+    {
+        // Arrange
+        var queueName = "test-queue";
+
+        // Act
+        var result = _requestResponseBuilder.ReplyToQueue(queueName);
+
+        // Assert
+        result.Should().BeSameAs(_requestResponseBuilder);
+        _requestResponseBuilder.Settings.Path.Should().Be(queueName);
+        _requestResponseBuilder.Settings.PathKind.Should().Be(PathKind.Queue);
+    }
+
+    #endregion
+
+    #region ReplyToQueue with builderConfig Tests
+
+    [Fact]
+    public void When_ReplyToQueue_BuilderConfig_Given_NullBuilder_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => NatsRequestResponseBuilderExtensions.ReplyToQueue(null, "test-queue", (_) => { });
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsBuilder");
+    }
+
+    [Fact]
+    public void When_ReplyToQueue_BuilderConfig_Given_NullQueueName_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => _requestResponseBuilder.ReplyToQueue(null, (_) => { });
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsQueue");
+    }
+
+    [Fact]
+    public void When_ReplyToQueue_BuilderConfig_Given_NullBuilderConfig_Then_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => _requestResponseBuilder.ReplyToQueue("test-queue", null);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("natsBuilderConfig");
+    }
+
+    [Fact]
+    public void When_ReplyToQueue_BuilderConfig_Given_ValidParameters_Then_SetsDefaultPathAndQueuePathKind()
+    {
+        // Arrange
+        var queueName = "test-queue";
+
+        // Act
+        var result = _requestResponseBuilder.ReplyToQueue(queueName, (_) => { });
+
+        // Assert
+        result.Should().BeSameAs(_requestResponseBuilder);
+        _requestResponseBuilder.Settings.Path.Should().Be(queueName);
+        _requestResponseBuilder.Settings.PathKind.Should().Be(PathKind.Queue);
+    }
+
+    #endregion
+}

--- a/src/Tests/SlimMessageBus.Host.Test/MessageBusBaseTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/MessageBusBaseTests.cs
@@ -786,6 +786,7 @@ public class MessageBusBaseTests : IDisposable
 
         // trigger lazy bus creation here ahead of the Tasks
         var bus = Bus;
+        bus.Settings.AutoStartConsumers = false;
 
         await bus.Start();
 


### PR DESCRIPTION
<!-- TITLE -->
#### [Host.Nats] Add queue support

<!-- DESCRIPTION -->
As stated in library description:
> Supports multiple messaging patterns: pub/sub, request-response, queues

This PR adds missing `queue` pattern to Nats transport via [QueueGroup](https://docs.nats.io/nats-concepts/core-nats/queue).
PR highly based on `Redis` transport code
