### PR TITLE
[Host.RabbitMQ] Add publisher confirms support #360

### DIFF
--- a/src/SlimMessageBus.Host.RabbitMQ/ChannelSnapshot.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/ChannelSnapshot.cs
@@ -1,0 +1,26 @@
+namespace SlimMessageBus.Host.RabbitMQ;
+
+using global::RabbitMQ.Client;
+
+/// <summary>
+/// An immutable snapshot of the current RabbitMQ channels, captured atomically to avoid
+/// time-of-check-time-of-use (TOCTOU) races between channel availability checks and publish operations.
+/// </summary>
+internal readonly struct ChannelSnapshot
+{
+    /// <summary>
+    /// The regular (fire-and-forget) channel.
+    /// </summary>
+    public IChannel Channel { get; }
+
+    /// <summary>
+    /// The channel with publisher confirms enabled, or <c>null</c> if no producer requires confirms.
+    /// </summary>
+    public IChannel ConfirmsChannel { get; }
+
+    public ChannelSnapshot(IChannel channel, IChannel confirmsChannel)
+    {
+        Channel = channel;
+        ConfirmsChannel = confirmsChannel;
+    }
+}

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqHasProviderExtensions.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqHasProviderExtensions.cs
@@ -16,4 +16,11 @@ static internal class RabbitMqHasProviderExtensions
 
     public static string GetExchangeType(this ProducerSettings p, HasProviderExtensions settings = null)
         => p.GetOrDefault<string>(RabbitMqProperties.ExchangeType, settings, null);
+
+    /// <summary>
+    /// Resolves whether publisher confirms are enabled for the given producer.
+    /// Producer-level setting takes precedence over bus-level setting.
+    /// </summary>
+    public static bool IsPublisherConfirmsEnabled(this ProducerSettings p, RabbitMqMessageBusSettings providerSettings)
+        => p.GetOrDefault<bool?>(RabbitMqProperties.EnablePublisherConfirms, null) ?? providerSettings.EnablePublisherConfirms;
 }

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqMessageBusSettingsExtensions.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqMessageBusSettingsExtensions.cs
@@ -67,6 +67,55 @@ public static class RabbitMqMessageBusSettingsExtensions
     }
 
     /// <summary>
+    /// Sets an modifier action for the message properties (headers) on the bus level. The content type, message id, and other RabbitMQ message properties can be set that way.
+    /// </summary>
+    /// <param name="settings"></param>
+    /// <param name="messagePropertiesModifier"></param>
+    /// <returns></returns>
+    public static RabbitMqMessageBusSettings UseMessagePropertiesModifier(this RabbitMqMessageBusSettings settings, RabbitMqMessagePropertiesModifier<object> messagePropertiesModifier)
+    {
+        if (settings is null) throw new ArgumentNullException(nameof(settings));
+        if (messagePropertiesModifier is null) throw new ArgumentNullException(nameof(messagePropertiesModifier));
+
+        RabbitMqProperties.MessagePropertiesModifier.Set(settings, messagePropertiesModifier);
+        return settings;
+    }
+
+    /// <summary>
+    /// Enables RabbitMQ Publisher Confirms. When enabled, the channel will be created in confirm mode
+    /// and each <c>BasicPublishAsync</c> call will wait for broker acknowledgement before completing.
+    /// This provides guaranteed message delivery at the cost of reduced throughput.
+    /// The default timeout of 10 seconds is used unless overridden via <see cref="RabbitMqMessageBusSettings.PublisherConfirmsTimeout"/>.
+    /// </summary>
+    /// <param name="settings"></param>
+    /// <returns></returns>
+    /// <remarks>
+    /// See https://www.rabbitmq.com/docs/confirms#publisher-confirms for more information.
+    /// </remarks>
+    public static RabbitMqMessageBusSettings UsePublisherConfirms(this RabbitMqMessageBusSettings settings)
+    {
+        if (settings is null) throw new ArgumentNullException(nameof(settings));
+
+        settings.EnablePublisherConfirms = true;
+        return settings;
+    }
+
+    /// <summary>
+    /// Enables RabbitMQ Publisher Confirms with a custom timeout.
+    /// </summary>
+    /// <param name="settings"></param>
+    /// <param name="timeout">The timeout for waiting for broker acknowledgement. A <see cref="ProducerMessageBusException"/> is thrown if the broker does not respond within the given time.</param>
+    /// <returns></returns>
+    public static RabbitMqMessageBusSettings UsePublisherConfirms(this RabbitMqMessageBusSettings settings, TimeSpan timeout)
+    {
+        if (settings is null) throw new ArgumentNullException(nameof(settings));
+
+        settings.EnablePublisherConfirms = true;
+        settings.PublisherConfirmsTimeout = timeout;
+        return settings;
+    }
+
+    /// <summary>
     /// Sets the default settings for queues on the bus level. This default will be taken unless it is overridden at the relevant consumer level.
     /// </summary>
     /// <param name="settings"></param>
@@ -85,21 +134,6 @@ public static class RabbitMqMessageBusSettingsExtensions
         {
             RabbitMqProperties.QueueAutoDelete.Set(settings, autoDelete.Value);
         }
-        return settings;
-    }
-
-    /// <summary>
-    /// Sets an modifier action for the message properties (headers) on the bus level. The content type, message id, and other RabbitMQ message properties can be set that way.
-    /// </summary>
-    /// <param name="settings"></param>
-    /// <param name="messagePropertiesModifier"></param>
-    /// <returns></returns>
-    public static RabbitMqMessageBusSettings UseMessagePropertiesModifier(this RabbitMqMessageBusSettings settings, RabbitMqMessagePropertiesModifier<object> messagePropertiesModifier)
-    {
-        if (settings is null) throw new ArgumentNullException(nameof(settings));
-        if (messagePropertiesModifier is null) throw new ArgumentNullException(nameof(messagePropertiesModifier));
-
-        RabbitMqProperties.MessagePropertiesModifier.Set(settings, messagePropertiesModifier);
         return settings;
     }
 

--- a/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqProperties.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Config/RabbitMqProperties.cs
@@ -28,7 +28,9 @@ static internal class RabbitMqProperties
 
     public static readonly ProviderExtensionProperty<BasicDeliverEventArgs> Message = new($"RabbitMQ_{nameof(Message)}");
 
-    public static readonly ProviderExtensionProperty<RabbitMqMessageBusSettings> ProviderSettings = new($"RabbitMQ_{nameof(ProviderSettings)}");
+    public static readonly ProviderExtensionProperty<bool?> EnablePublisherConfirms = new($"RabbitMQ_{nameof(EnablePublisherConfirms)}");
 
     public static readonly ProviderExtensionProperty<RabbitMqMessageAcknowledgementMode?> MessageAcknowledgementMode = new($"RabbitMQ_{nameof(MessageAcknowledgementMode)}");
+
+    public static readonly ProviderExtensionProperty<RabbitMqMessageBusSettings> ProviderSettings = new($"RabbitMQ_{nameof(ProviderSettings)}");
 }

--- a/src/SlimMessageBus.Host.RabbitMQ/Consumers/AbstractRabbitMqConsumer.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Consumers/AbstractRabbitMqConsumer.cs
@@ -1,4 +1,4 @@
-﻿namespace SlimMessageBus.Host.RabbitMQ;
+namespace SlimMessageBus.Host.RabbitMQ;
 
 using global::RabbitMQ.Client;
 using global::RabbitMQ.Client.Events;

--- a/src/SlimMessageBus.Host.RabbitMQ/RabbitMqChannelManager.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/RabbitMqChannelManager.cs
@@ -18,6 +18,7 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
 
     private IConnection _connection;
     private IChannel _channel;
+    private IChannel _confirmsChannel;
 
     // Use SemaphoreSlim for async-compatible locking
     private readonly SemaphoreSlim _channelLock = new(1, 1);
@@ -28,6 +29,7 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
     private readonly Timer _connectionRetryTimer;
     private readonly TimeSpan _connectionRetryInterval;
     private int _disposed; // 0 = not disposed, 1 = disposed
+    private bool? _needsConfirmsChannel; // Cached result of NeedsConfirmsChannel()
 
     /// <summary>
     /// Event raised when the channel has been successfully recovered after a connection loss.
@@ -40,6 +42,11 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
     /// </summary>
     public IChannel Channel => _channel;
 
+    /// <summary>
+    /// Gets the channel with publisher confirms enabled, or <c>null</c> if no producer requires confirms.
+    /// </summary>
+    public IChannel ConfirmsChannel => _confirmsChannel;
+
     public RabbitMqChannelManager(
         ILoggerFactory loggerFactory,
         RabbitMqMessageBusSettings providerSettings,
@@ -51,7 +58,6 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
         _providerSettings = providerSettings ?? throw new ArgumentNullException(nameof(providerSettings));
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         _isDisposingOrDisposed = isDisposingOrDisposed ?? throw new ArgumentNullException(nameof(isDisposingOrDisposed));
-
 
         // Set up connection retry interval (default to NetworkRecoveryInterval or 10 seconds)
         var networkRecoveryInterval = _providerSettings.ConnectionFactory.NetworkRecoveryInterval;
@@ -107,10 +113,14 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
 
     /// <summary>
     /// Ensures the channel is available, triggering reconnection if necessary.
+    /// Returns a snapshot of both channels to avoid TOCTOU races between check and use.
     /// </summary>
-    public void EnsureChannel()
+    public ChannelSnapshot EnsureChannel()
     {
-        if (_channel == null)
+        var channel = _channel;
+        var confirmsChannel = _confirmsChannel;
+
+        if (channel == null)
         {
             // If channel is null, trigger immediate reconnection attempt
             // The semaphore in EstablishConnection will prevent concurrent attempts
@@ -119,6 +129,8 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
 
             throw new ProducerMessageBusException("The Channel is not available at this time");
         }
+
+        return new ChannelSnapshot(channel, confirmsChannel);
     }
 
     private async Task<bool> EstablishConnection()
@@ -145,8 +157,11 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
             // Subscribe to connection shutdown events for better resilience
             newConnection.ConnectionShutdownAsync += OnConnectionShutdownAsync;
 
+            var needsConfirmsChannel = NeedsConfirmsChannel();
+
             IConnection oldConnection = null;
             IChannel oldChannel = null;
+            IChannel oldConfirmsChannel = null;
             var isRecovery = false;
 
             // Use semaphore instead of lock for async safety
@@ -162,10 +177,12 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
                     // Store old resources for cleanup outside lock
                     oldConnection = _connection;
                     oldChannel = _channel;
+                    oldConfirmsChannel = _confirmsChannel;
                 }
 
                 _connection = newConnection;
                 _channel = null; // Will be set after creation
+                _confirmsChannel = null;
             }
             finally
             {
@@ -173,6 +190,10 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
             }
 
             // Cleanup old resources outside the lock
+            if (oldConfirmsChannel != null)
+            {
+                await CloseAndDisposeChannelAsync(oldConfirmsChannel);
+            }
             if (oldChannel != null)
             {
                 await CloseAndDisposeChannelAsync(oldChannel);
@@ -182,22 +203,30 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
                 await CloseAndDisposeConnectionAsync(oldConnection);
             }
 
-            // Create channel outside the lock to avoid holding lock during async operation
+            // Create channels outside the lock to avoid holding lock during async operations
             if (_connection != null)
             {
                 var newChannel = await _connection.CreateChannelAsync();
+
+                IChannel newConfirmsChannel = null;
+                if (needsConfirmsChannel)
+                {
+                    newConfirmsChannel = await _connection.CreateChannelAsync(
+                        new CreateChannelOptions(publisherConfirmationsEnabled: true, publisherConfirmationTrackingEnabled: true));
+                }
 
                 await _channelLock.WaitAsync();
                 try
                 {
                     _channel = newChannel;
+                    _confirmsChannel = newConfirmsChannel;
                 }
                 finally
                 {
                     _channelLock.Release();
                 }
 
-                // Provision topology
+                // Provision topology (uses the main channel)
                 await ProvisionTopology();
             }
 
@@ -219,6 +248,29 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
         {
             _connectionSemaphore.Release();
         }
+    }
+
+    /// <summary>
+    /// Determines if a separate confirms channel is needed based on bus-level and producer-level settings.
+    /// The result is cached after the first call since producer configuration does not change at runtime.
+    /// </summary>
+    internal bool NeedsConfirmsChannel()
+    {
+        _needsConfirmsChannel ??= ComputeNeedsConfirmsChannel();
+        return _needsConfirmsChannel.Value;
+    }
+
+    private bool ComputeNeedsConfirmsChannel()
+    {
+        // If bus-level confirms are enabled, we always need a confirms channel
+        // (some producers might opt out and use the regular channel)
+        if (_providerSettings.EnablePublisherConfirms)
+        {
+            return true;
+        }
+
+        // Check if any producer explicitly enables confirms
+        return _settings.Producers.Any(p => p.GetOrDefault<bool?>(RabbitMqProperties.EnablePublisherConfirms, null) == true);
     }
 
     private async Task ProvisionTopology()
@@ -265,9 +317,9 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
         if (_isDisposingOrDisposed())
             return;
 
-        // The connection semaphore in EstablishConnection will prevent concurrent attempts
+        // Use one-shot timer (Timeout.Infinite for period) to avoid piling up fire-and-forget tasks
         LogStartingConnectionRetryTimer(_connectionRetryInterval);
-        _connectionRetryTimer.Change(_connectionRetryInterval, _connectionRetryInterval);
+        _connectionRetryTimer.Change(_connectionRetryInterval, Timeout.InfiniteTimeSpan);
     }
 
     private void OnConnectionRetryTimer(object state)
@@ -276,7 +328,8 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
             return;
 
         // Check if connection is already healthy (quick check without lock)
-        if (_connection?.IsOpen == true && _channel?.IsOpen == true)
+        if (_connection?.IsOpen == true && _channel?.IsOpen == true
+            && (_confirmsChannel == null || _confirmsChannel.IsOpen))
         {
             LogConnectionIsHealthy();
             _connectionRetryTimer.Change(Timeout.Infinite, Timeout.Infinite);
@@ -298,16 +351,19 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
                 if (success)
                 {
                     LogReconnectionSuccessful();
-                    _connectionRetryTimer.Change(Timeout.Infinite, Timeout.Infinite);
                 }
                 else
                 {
                     LogReconnectionFailed(_connectionRetryInterval);
+                    // Re-arm the one-shot timer for the next attempt
+                    StartConnectionRetryTimer();
                 }
             }
             catch (Exception ex)
             {
                 LogErrorDuringReconnectionAttempt(ex.Message, ex);
+                // Re-arm the one-shot timer for the next attempt
+                StartConnectionRetryTimer();
             }
         });
     }
@@ -399,7 +455,7 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
             _connectionRetryTimer?.Dispose();
 
             // For synchronous dispose, we have to block (not ideal but necessary for IDisposable)
-            DisposeAsyncCore().AsTask().GetAwaiter().GetResult();
+            DisposeResourcesAsync().AsTask().GetAwaiter().GetResult();
         }
     }
 
@@ -418,17 +474,29 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
 #endif
         }
 
+        await DisposeResourcesAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Shared cleanup method called by both synchronous and asynchronous dispose paths.
+    /// Must only be called once (guarded by the <see cref="_disposed"/> flag in the callers).
+    /// </summary>
+    private async ValueTask DisposeResourcesAsync()
+    {
         IConnection connectionToDispose = null;
         IChannel channelToDispose = null;
+        IChannel confirmsChannelToDispose = null;
 
         // Acquire lock to safely extract resources
         await _channelLock.WaitAsync().ConfigureAwait(false);
         try
         {
             channelToDispose = _channel;
+            confirmsChannelToDispose = _confirmsChannel;
             connectionToDispose = _connection;
 
             _channel = null;
+            _confirmsChannel = null;
             _connection = null;
 
             // Unsubscribe from events
@@ -440,6 +508,11 @@ internal partial class RabbitMqChannelManager : IRabbitMqChannel, IAsyncDisposab
         }
 
         // Dispose resources outside the lock
+        if (confirmsChannelToDispose != null)
+        {
+            await CloseAndDisposeChannelAsync(confirmsChannelToDispose).ConfigureAwait(false);
+        }
+
         if (channelToDispose != null)
         {
             await CloseAndDisposeChannelAsync(channelToDispose).ConfigureAwait(false);

--- a/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBus.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBus.cs
@@ -1,4 +1,4 @@
-﻿namespace SlimMessageBus.Host.RabbitMQ;
+namespace SlimMessageBus.Host.RabbitMQ;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -83,17 +83,23 @@ public class RabbitMqMessageBus : MessageBusBase<RabbitMqMessageBusSettings>, IR
         {
             OnProduceToTransport(message, messageType, path, messageHeaders);
 
-            _channelManager.EnsureChannel();
-
+            var channels = _channelManager.EnsureChannel();
             // IChannel is thread-safe in v7 - no locking needed
-            GetTransportMessage(message, messageType, messageHeaders, path, out var messagePayload, out var messageProperties, out var routingKey);
-            await _channelManager.Channel.BasicPublishAsync(
+            GetTransportMessage(message, messageType, messageHeaders, path, channels, out var messagePayload, out var messageProperties, out var routingKey, out var useConfirms, out var producerChannel);
+            using var timeoutCts = CreateConfirmsTimeoutCts(useConfirms, cancellationToken, out var effectiveToken);
+
+            await producerChannel.BasicPublishAsync(
                 exchange: path,
                 routingKey: routingKey,
                 mandatory: false,
                 basicProperties: (BasicProperties)messageProperties,
                 body: messagePayload,
-                cancellationToken: cancellationToken);
+                cancellationToken: effectiveToken);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The caller's token was not cancelled - this was our confirms timeout
+            throw new ProducerMessageBusException($"Publisher confirm timed out after {ProviderSettings.PublisherConfirmsTimeout} for message of type {messageType} on path {path}", ex);
         }
         catch (Exception ex) when (ex is not ProducerMessageBusException && ex is not TaskCanceledException)
         {
@@ -103,34 +109,68 @@ public class RabbitMqMessageBus : MessageBusBase<RabbitMqMessageBusSettings>, IR
 
     public override async Task<ProduceToTransportBulkResult<T>> ProduceToTransportBulk<T>(IReadOnlyCollection<T> envelopes, string path, IMessageBusTarget targetBus, CancellationToken cancellationToken)
     {
+        var dispatched = new List<T>(envelopes.Count);
         try
         {
-            _channelManager.EnsureChannel();
+            var channels = _channelManager.EnsureChannel();
 
             // IChannel is thread-safe in v7 - no locking needed
+            // BasicPublishAsync waits for publisher confirms automatically when the confirms channel is used
             foreach (var envelope in envelopes)
             {
-                GetTransportMessage(envelope.Message, envelope.MessageType, envelope.Headers, path, out var messagePayload, out var messageProperties, out var routingKey);
-                await _channelManager.Channel.BasicPublishAsync(
+                GetTransportMessage(envelope.Message, envelope.MessageType, envelope.Headers, path, channels, out var messagePayload, out var messageProperties, out var routingKey, out var useConfirms, out var producerChannel);
+                using var timeoutCts = CreateConfirmsTimeoutCts(useConfirms, cancellationToken, out var effectiveToken);
+
+                await producerChannel.BasicPublishAsync(
                     exchange: path,
                     routingKey: routingKey,
                     mandatory: false,
                     basicProperties: (BasicProperties)messageProperties,
                     body: messagePayload,
-                    cancellationToken: cancellationToken);
+                    cancellationToken: effectiveToken);
+
+                dispatched.Add(envelope);
             }
 
             return new ProduceToTransportBulkResult<T>(envelopes, null);
         }
         catch (Exception ex)
         {
-            return new ProduceToTransportBulkResult<T>([], ex);
+            return new ProduceToTransportBulkResult<T>(dispatched, ex);
         }
     }
 
-    private void GetTransportMessage(object message, Type messageType, IDictionary<string, object> messageHeaders, string path, out byte[] messagePayload, out IBasicProperties messageProperties, out string routingKey)
+    /// <summary>
+    /// Creates a linked <see cref="CancellationTokenSource"/> with the configured publisher confirms timeout,
+    /// or returns <c>null</c> if no timeout is configured or confirms are not in use.
+    /// </summary>
+    private CancellationTokenSource CreateConfirmsTimeoutCts(bool useConfirms, CancellationToken callerToken, out CancellationToken effectiveToken)
+    {
+        if (useConfirms && ProviderSettings.PublisherConfirmsTimeout is { } timeout)
+        {
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(callerToken);
+            cts.CancelAfter(timeout);
+            effectiveToken = cts.Token;
+            return cts;
+        }
+
+        effectiveToken = callerToken;
+        return null;
+    }
+
+    private void GetTransportMessage(object message, Type messageType, IDictionary<string, object> messageHeaders, string path, ChannelSnapshot channels, out byte[] messagePayload, out IBasicProperties messageProperties, out string routingKey, out bool useConfirms, out IChannel producerChannel)
     {
         var producer = GetProducerSettings(messageType);
+        useConfirms = producer != null && producer.IsPublisherConfirmsEnabled(ProviderSettings);
+        if (useConfirms)
+        {
+            producerChannel = channels.ConfirmsChannel
+                ?? throw new ProducerMessageBusException("Publisher confirms are enabled but the confirms channel is not available. This may indicate a reconnection is in progress.");
+        }
+        else
+        {
+            producerChannel = channels.Channel;
+        }
         messagePayload = SerializerProvider.GetSerializer(path).Serialize(messageType, messageHeaders, message, null);
 
         // IChannel is thread-safe in v7 - create properties without external locking

--- a/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBusSettings.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/RabbitMqMessageBusSettings.cs
@@ -18,6 +18,17 @@ public class RabbitMqMessageBusSettings : HasProviderExtensions
         ConsumerDispatchConcurrency = 1
     };
 
+    /// <summary>
+    /// Enables RabbitMQ Publisher Confirms. When enabled, the channel will be created in confirm mode
+    /// and each <c>BasicPublishAsync</c> call will wait for broker acknowledgement before completing.
+    /// This provides guaranteed message delivery at the cost of reduced throughput.
+    /// Default is <c>false</c> (opt-in).
+    /// </summary>
+    /// <remarks>
+    /// See https://www.rabbitmq.com/docs/confirms#publisher-confirms for more information.
+    /// </remarks>
+    public bool EnablePublisherConfirms { get; set; }
+
     public IList<AmqpTcpEndpoint> Endpoints { get; set; } = [];
 
     /// <summary>
@@ -31,5 +42,13 @@ public class RabbitMqMessageBusSettings : HasProviderExtensions
     /// By default the message is Acknowledged.
     /// </summary>
     public RabbitMqMessageUnrecognizedRoutingKeyHandler MessageUnrecognizedRoutingKeyHandler { get; set; } = (_) => RabbitMqMessageConfirmOptions.Ack;
+
+    /// <summary>
+    /// The maximum time to wait for the broker to acknowledge a published message when publisher confirms are enabled.
+    /// If the broker does not respond within this timeout, a <see cref="ProducerMessageBusException"/> is thrown.
+    /// Only applicable when publisher confirms are enabled (bus-level or producer-level).
+    /// Default is 10 seconds. Set to <c>null</c> to disable the timeout and rely solely on the caller's cancellation token.
+    /// </summary>
+    public TimeSpan? PublisherConfirmsTimeout { get; set; } = TimeSpan.FromSeconds(10);
 }
 

--- a/src/SlimMessageBus.Host.RabbitMQ/SlimMessageBus.Host.RabbitMQ.csproj
+++ b/src/SlimMessageBus.Host.RabbitMQ/SlimMessageBus.Host.RabbitMQ.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 

--- a/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test/OutboxBenchmarkTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test/OutboxBenchmarkTests.cs
@@ -1,4 +1,4 @@
-﻿namespace SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test;
+namespace SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test;
 
 
 [CollectionDefinition(nameof(OutboxBenchmarkTestsCollection))]

--- a/src/Tests/SlimMessageBus.Host.Outbox.Sql.DbContext.Test/OutboxBenchmarkTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.Sql.DbContext.Test/OutboxBenchmarkTests.cs
@@ -1,4 +1,4 @@
-﻿namespace SlimMessageBus.Host.Outbox.Sql.DbContext.Test;
+namespace SlimMessageBus.Host.Outbox.Sql.DbContext.Test;
 
 using System.Net.Mime;
 

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/Config/RabbitMqMessageBusSettingsExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/Config/RabbitMqMessageBusSettingsExtensionsTests.cs
@@ -32,4 +32,42 @@ public class RabbitMqMessageBusSettingsExtensionsTests
         var routingKeyProviderReturned = _settings.GetOrDefault(RabbitMqProperties.MessageRoutingKeyProvider);
         routingKeyProviderReturned.Should().BeSameAs(routingKeyProviderMock.Object);
     }
+
+    [Fact]
+    internal void When_UsePublisherConfirms_Then_EnabledWithDefaultTimeout()
+    {
+        // act
+        _settings.UsePublisherConfirms();
+
+        // assert
+        _settings.EnablePublisherConfirms.Should().BeTrue();
+        _settings.PublisherConfirmsTimeout.Should().Be(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    internal void When_UsePublisherConfirms_Given_Timeout_Then_EnabledWithTimeout()
+    {
+        // arrange
+        var timeout = TimeSpan.FromSeconds(30);
+
+        // act
+        _settings.UsePublisherConfirms(timeout);
+
+        // assert
+        _settings.EnablePublisherConfirms.Should().BeTrue();
+        _settings.PublisherConfirmsTimeout.Should().Be(timeout);
+    }
+
+    [Fact]
+    internal void When_UsePublisherConfirms_Given_NullSettings_Then_ShouldThrowArgumentNullException()
+    {
+        // arrange
+        RabbitMqMessageBusSettings nullSettings = null;
+
+        // act
+        var act = () => nullSettings.UsePublisherConfirms();
+
+        // assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("settings");
+    }
 }

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/Config/RabbitMqProducerBuilderExtensionsTests.cs
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/Config/RabbitMqProducerBuilderExtensionsTests.cs
@@ -1,0 +1,91 @@
+namespace SlimMessageBus.Host.RabbitMQ.Test.Config;
+
+public class RabbitMqProducerBuilderExtensionsTests
+{
+    private readonly MessageBusSettings _busSettings = new();
+    private readonly RabbitMqMessageBusSettings _providerSettings = new();
+
+    [Fact]
+    internal void When_EnablePublisherConfirms_Then_ValueStoredProperly()
+    {
+        // arrange
+        var builder = new ProducerBuilder<object>(new ProducerSettings());
+
+        // act
+        builder.EnablePublisherConfirms();
+
+        // assert
+        builder.Settings.GetOrDefault<bool?>(RabbitMqProperties.EnablePublisherConfirms, null).Should().BeTrue();
+    }
+
+    [Fact]
+    internal void When_EnablePublisherConfirms_Given_False_Then_ValueStoredProperly()
+    {
+        // arrange
+        var builder = new ProducerBuilder<object>(new ProducerSettings());
+
+        // act
+        builder.EnablePublisherConfirms(enabled: false);
+
+        // assert
+        builder.Settings.GetOrDefault<bool?>(RabbitMqProperties.EnablePublisherConfirms, null).Should().BeFalse();
+    }
+
+    [Fact]
+    internal void When_IsPublisherConfirmsEnabled_Given_ProducerEnabled_And_BusDisabled_Then_ReturnsTrue()
+    {
+        // arrange
+        var producerSettings = new ProducerSettings();
+        RabbitMqProperties.EnablePublisherConfirms.Set(producerSettings, true);
+        _providerSettings.EnablePublisherConfirms = false;
+
+        // act
+        var result = producerSettings.IsPublisherConfirmsEnabled(_providerSettings);
+
+        // assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    internal void When_IsPublisherConfirmsEnabled_Given_ProducerDisabled_And_BusEnabled_Then_ReturnsFalse()
+    {
+        // arrange
+        var producerSettings = new ProducerSettings();
+        RabbitMqProperties.EnablePublisherConfirms.Set(producerSettings, false);
+        _providerSettings.EnablePublisherConfirms = true;
+
+        // act
+        var result = producerSettings.IsPublisherConfirmsEnabled(_providerSettings);
+
+        // assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    internal void When_IsPublisherConfirmsEnabled_Given_ProducerNotSet_And_BusEnabled_Then_ReturnsTrue()
+    {
+        // arrange
+        var producerSettings = new ProducerSettings();
+        _providerSettings.EnablePublisherConfirms = true;
+
+        // act
+        var result = producerSettings.IsPublisherConfirmsEnabled(_providerSettings);
+
+        // assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    internal void When_IsPublisherConfirmsEnabled_Given_ProducerNotSet_And_BusDisabled_Then_ReturnsFalse()
+    {
+        // arrange
+        var producerSettings = new ProducerSettings();
+        _providerSettings.EnablePublisherConfirms = false;
+
+        // act
+        var result = producerSettings.IsPublisherConfirmsEnabled(_providerSettings);
+
+        // assert
+        result.Should().BeFalse();
+    }
+}

--- a/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/IntegrationTests/RabbitMqMessageBusIt.cs
+++ b/src/Tests/SlimMessageBus.Host.RabbitMQ.Test/IntegrationTests/RabbitMqMessageBusIt.cs
@@ -179,7 +179,7 @@ public class RabbitMqMessageBusIt(ITestOutputHelper output) : BaseIntegrationTes
         var totalExpectedCount = expectedConsumedCount * expectedMessageCopies;
 
         // Wait for all expected messages with a longer timeout to ensure message delivery
-        await consumedMessages.WaitUntilArriving(newMessagesTimeout: 15, expectedCount: totalExpectedCount);
+        await consumedMessages.WaitUntilArriving(newMessagesTimeout: 30, expectedCount: totalExpectedCount);
 
         stopwatch.Stop();
 
@@ -206,6 +206,54 @@ public class RabbitMqMessageBusIt(ITestOutputHelper output) : BaseIntegrationTes
             ConsumedMessages = consumedMessages.Snapshot(),
             TestMetric = testMetric
         });
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task PubSubWithPublisherConfirms(bool busLevelConfirms)
+    {
+        var topic = "test-ping";
+
+        AddBusConfiguration(mbb =>
+        {
+            if (busLevelConfirms)
+            {
+                mbb.WithProviderRabbitMQ(cfg =>
+                {
+                    cfg.UsePublisherConfirms();
+                });
+            }
+
+            mbb
+                .Produce<PingMessage>(x =>
+                {
+                    x.Exchange(topic, exchangeType: ExchangeType.Fanout);
+                    if (!busLevelConfirms)
+                    {
+                        // Enable confirms at the producer level only
+                        x.EnablePublisherConfirms();
+                    }
+                    x.MessagePropertiesModifier((m, p) =>
+                    {
+                        p.MessageId = GetMessageId(m);
+                    });
+                    x.WithHeaderModifier((h, m) =>
+                    {
+                        h["Counter"] = m.Counter;
+                        h["Even"] = m.Counter % 2 == 0;
+                    });
+                })
+                .Consume<PingMessage>(x => x
+                    .Queue("subscriber-0", autoDelete: false)
+                    .ExchangeBinding(topic)
+                    .DeadLetterExchange("subscriber-dlq")
+                    .AcknowledgementMode(RabbitMqMessageAcknowledgementMode.ConfirmAfterMessageProcessingWhenNoManualConfirmMade)
+                    .WithConsumer<PingConsumer>()
+                    .WithConsumer<PingDerivedConsumer, PingDerivedMessage>());
+        });
+
+        await BasicPubSub(expectedMessageCopies: 1);
     }
 
     [Theory]

--- a/src/Tests/SlimMessageBus.Host.Test.Common/IntegrationTest/BaseIntegrationTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test.Common/IntegrationTest/BaseIntegrationTest.cs
@@ -37,7 +37,7 @@ public abstract class BaseIntegrationTest<T> : IAsyncLifetime
             .ReadFrom.Configuration(Configuration)
             .CreateLogger();
 
-        Secrets.Load(@"..\..\..\..\..\secrets.txt");
+        Secrets.Load(Path.Combine("..", "..", "..", "..", "..", "secrets.txt"));
 
         _serviceProvider = new Lazy<ServiceProvider>(() =>
         {


### PR DESCRIPTION
## Summary

Adds opt-in [Publisher Confirms](https://www.rabbitmq.com/docs/confirms#publisher-confirms) to the RabbitMQ transport provider, as discussed in #360. This addresses the issue where the outbox would mark messages as delivered even when the RabbitMQ broker was unreachable, causing silent message loss.

Built on top of the RabbitMQ.Client 7.x upgrade from #450.

### What's included

- **Bus-level and per-producer configuration** — enable globally with `UsePublisherConfirms()`, override per-producer with `.EnablePublisherConfirms(true/false)`, configurable timeout (default 10s)
- **Dedicated confirms channel** so non-critical fire-and-forget producers are not slowed down by confirm round-trips
- **Immutable `ChannelSnapshot`** returned from `EnsureChannel()` to eliminate TOCTOU race between availability check and publish
- **Partial failure tracking in bulk publish** — `ProduceToTransportBulk` now returns only the actually-dispatched envelopes, so the outbox doesn't report confirmed messages as failed on retry
- **Fixed double-dispose bug** where `Dispose(bool)` set the disposed flag then called `DisposeAsyncCore()` which saw the flag and returned without cleaning up
- **One-shot reconnection timer** instead of periodic to prevent fire-and-forget task pileup
- **Throws on confirms channel unavailability** instead of silently falling back to the non-confirms channel
- **Documentation** with usage examples, trade-offs, and the unroutable message caveat


### Known issues

- **Outbox retries exhaust quickly when broker is down.** When the RabbitMQ broker is unreachable, `EnsureChannel()` throws immediately on every dispatch attempt. The outbox dispatcher retries in rapid succession, consuming all `MaxDeliveryAttempts` within seconds rather than backing off. A short-circuit mechanism in the outbox dispatcher — skipping dispatch attempts while the transport reports unhealthy and resuming when the connection recovers — would prevent this. This is a transport-agnostic outbox concern and should be addressed separately. I believe I saw a branch that adds the short-circuit but just wanted to call that out here as I noticed this issue in local testing.

## Test plan

- [x] 174 unit tests pass
- [x] Stress tested locally with broker up/down scenarios
- [x] New tests for `NeedsConfirmsChannel` (bus × producer level combinations)
- [x] New tests for `EnablePublisherConfirms` builder extension and override logic
- [x] Integration test: confirms enabled, verify ACK completes publish
- [x] Integration test: broker down → outbox retries → broker restored → message delivered
- [x] Integration test: NACK scenario

Resolves #360
