### PR TITLE
[Host.Kafka] Add KafkaLoopFailureInterceptor

### DIFF
--- a/docs/provider_kafka.md
+++ b/docs/provider_kafka.md
@@ -17,6 +17,8 @@ Please read the [Introduction](intro.md) before reading this provider documentat
   - [Offset Commit](#offset-commit)
   - [Consumer Error Handling](#consumer-error-handling)
   - [Debugging](#debugging)
+- [Interceptors](#interceptors)
+  - [Consumer Loop Failure Interceptor](#consumer-loop-failure-interceptor)
 - [Deployment](#deployment)
 
 ## Underlying client
@@ -300,6 +302,21 @@ At this logging level, you can track the lifecycle events of the consumer group:
 [00:03:16 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Reached end of partition, Topic: 4p5ma6io-test-ping, Partition: [1], Offset: 98580
 [00:03:16 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Commit Offset, Topic: 4p5ma6io-test-ping, Partition: [1], Offset: 98579
 ```
+
+## Interceptors
+
+### Consumer Loop Failure Interceptor
+
+The `IKafkaLoopFailureInterceptor` provides a mechanism to intercept and handle fatal exceptions that occur within the main Kafka consumer group loop managed by KafkaGroupConsumer. These exceptions are typically unrecoverable errors that cause the consumer group's processing thread to terminate.
+Instances of `IKafkaLoopFailureInterceptor` are resolved from the DI container. They are executed in order, when a fatal exception occurs within the consumer loop.
+
+```cs
+public interface IKafkaLoopFailureInterceptor : IInterceptorWithOrder
+{
+    Task OnFailureAsync(KafkaLoopFailureContext context);
+}
+```
+Remember to register your interceptor types in the DI.
 
 ## Deployment
 

--- a/docs/provider_kafka.t.md
+++ b/docs/provider_kafka.t.md
@@ -17,6 +17,8 @@ Please read the [Introduction](intro.md) before reading this provider documentat
   - [Offset Commit](#offset-commit)
   - [Consumer Error Handling](#consumer-error-handling)
   - [Debugging](#debugging)
+- [Interceptors](#interceptors)
+  - [Consumer Loop Failure Interceptor](#consumer-loop-failure-interceptor)
 - [Deployment](#deployment)
 
 ## Underlying client
@@ -282,6 +284,21 @@ At this logging level, you can track the lifecycle events of the consumer group:
 [00:03:16 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Reached end of partition, Topic: 4p5ma6io-test-ping, Partition: [1], Offset: 98580
 [00:03:16 DBG] SlimMessageBus.Host.Kafka.KafkaGroupConsumer Group [subscriber]: Commit Offset, Topic: 4p5ma6io-test-ping, Partition: [1], Offset: 98579
 ```
+
+## Interceptors
+
+### Consumer Loop Failure Interceptor
+
+The `IKafkaLoopFailureInterceptor` provides a mechanism to intercept and handle fatal exceptions that occur within the main Kafka consumer group loop managed by KafkaGroupConsumer. These exceptions are typically unrecoverable errors that cause the consumer group's processing thread to terminate.
+Instances of `IKafkaLoopFailureInterceptor` are resolved from the DI container. They are executed in order, when a fatal exception occurs within the consumer loop.
+
+```cs
+public interface IKafkaLoopFailureInterceptor : IInterceptorWithOrder
+{
+    Task OnFailureAsync(KafkaLoopFailureContext context);
+}
+```
+Remember to register your interceptor types in the DI.
 
 ## Deployment
 

--- a/src/SlimMessageBus.Host.Kafka/Consumer/IKafkaLoopFailureInterceptor.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/IKafkaLoopFailureInterceptor.cs
@@ -1,0 +1,12 @@
+﻿namespace SlimMessageBus.Host.Kafka;
+
+using Interceptor;
+
+/// <summary>
+/// Provides a way to intercept fatal failures occurring within the Kafka consumer group loop (<see cref="KafkaGroupConsumer.ConsumerLoop"/>).
+/// These failures are typically unrecoverable errors that terminate the entire consumer group instance.
+/// </summary>
+public interface IKafkaLoopFailureInterceptor : IInterceptorWithOrder
+{
+    Task OnFailureAsync(KafkaLoopFailureContext context);
+}

--- a/src/SlimMessageBus.Host.Kafka/Consumer/KafkaGroupConsumer.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/KafkaGroupConsumer.cs
@@ -6,6 +6,7 @@ using IConsumer = IConsumer<Ignore, byte[]>;
 public class KafkaGroupConsumer : AbstractConsumer, IKafkaCommitController
 {
     private readonly SafeDictionaryWrapper<TopicPartition, IKafkaPartitionConsumer> _processors;
+    private readonly IReadOnlyList<IKafkaLoopFailureInterceptor> _failureInterceptors;
 
     private IConsumer _consumer;
     private Task _consumerTask;
@@ -19,6 +20,7 @@ public class KafkaGroupConsumer : AbstractConsumer, IKafkaCommitController
                               KafkaMessageBusSettings providerSettings,
                               IEnumerable<AbstractConsumerSettings> consumerSettings,
                               IEnumerable<IAbstractConsumerInterceptor> interceptors,
+                              IEnumerable<IKafkaLoopFailureInterceptor> failureInterceptors,
                               string group,
                               IReadOnlyCollection<string> topics,
                               Func<TopicPartition, IKafkaCommitController, IKafkaPartitionConsumer> processorFactory)
@@ -36,6 +38,8 @@ public class KafkaGroupConsumer : AbstractConsumer, IKafkaCommitController
         _processors = new SafeDictionaryWrapper<TopicPartition, IKafkaPartitionConsumer>(tp => processorFactory(tp, this));
 
         _consumer = CreateConsumer(group);
+
+        _failureInterceptors = [..failureInterceptors.OrderBy(x => x.Order)];
     }
 
     #region Implementation of IAsyncDisposable
@@ -154,6 +158,18 @@ public class KafkaGroupConsumer : AbstractConsumer, IKafkaCommitController
         catch (Exception e)
         {
             Logger.LogError(e, "Group [{Group}]: Error occurred in group loop (terminated)", Group);
+            var failureContext = new KafkaLoopFailureContext(Group, e);
+            foreach (var interceptor in _failureInterceptors)
+            {
+                try
+                {
+                    await interceptor.OnFailureAsync(failureContext).ConfigureAwait(false);
+                }
+                catch (Exception interceptorEx)
+                {
+                    Logger.LogError(interceptorEx, "Group [{Group}]: Exception occurred in IKafkaGroupLoopFailureInterceptor '{InterceptorType}'", Group, interceptor.GetType().Name);
+                }
+            }
         }
         finally
         {

--- a/src/SlimMessageBus.Host.Kafka/Consumer/KafkaLoopFailureContext.cs
+++ b/src/SlimMessageBus.Host.Kafka/Consumer/KafkaLoopFailureContext.cs
@@ -1,0 +1,10 @@
+﻿namespace SlimMessageBus.Host.Kafka;
+
+/// <summary>
+/// Context object passed to <see cref="IKafkaLoopFailureInterceptor"/>.
+/// </summary>
+public class KafkaLoopFailureContext(string group, Exception exception)
+{
+    public string Group { get; } = group ?? throw new ArgumentNullException(nameof(group));
+    public Exception Exception { get; } = exception ?? throw new ArgumentNullException(nameof(exception));
+}

--- a/src/SlimMessageBus.Host.Kafka/KafkaMessageBus.cs
+++ b/src/SlimMessageBus.Host.Kafka/KafkaMessageBus.cs
@@ -66,7 +66,11 @@ public class KafkaMessageBus : MessageBusBase<KafkaMessageBusSettings>
         void AddGroupConsumer(IEnumerable<AbstractConsumerSettings> consumerSettings, string group, IReadOnlyCollection<string> topics, Func<TopicPartition, IKafkaCommitController, IKafkaPartitionConsumer> processorFactory)
         {
             _logger.LogInformation("Creating consumer group {ConsumerGroup}", group);
-            AddConsumer(new KafkaGroupConsumer(LoggerFactory, ProviderSettings, consumerSettings, interceptors: Settings.ServiceProvider.GetServices<IAbstractConsumerInterceptor>(), group, topics, processorFactory));
+            AddConsumer(new KafkaGroupConsumer(LoggerFactory, 
+                ProviderSettings, consumerSettings, 
+                interceptors: Settings.ServiceProvider.GetServices<IAbstractConsumerInterceptor>(), 
+                failureInterceptors: Settings.ServiceProvider.GetServices<IKafkaLoopFailureInterceptor>(),
+                group, topics, processorFactory));
         }
 
         MessageProvider<ConsumeResult<Ignore, byte[]>> GetMessageProvider(string path)

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaGroupConsumerTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaGroupConsumerTests.cs
@@ -15,7 +15,7 @@ public class KafkaGroupConsumerTests
         var providerSettings = new KafkaMessageBusSettings("host");
         var consumerSettings = Array.Empty<AbstractConsumerSettings>();
 
-        var subjectMock = new Mock<KafkaGroupConsumer>(loggerFactoryMock.Object, providerSettings, consumerSettings, Array.Empty<IAbstractConsumerInterceptor>(), "group", new List<string> { "topic" }, processorFactoryMock.Object) { CallBase = true };
+        var subjectMock = new Mock<KafkaGroupConsumer>(loggerFactoryMock.Object, providerSettings, consumerSettings, Array.Empty<IAbstractConsumerInterceptor>(), Array.Empty<IKafkaLoopFailureInterceptor>(), "group", new List<string> { "topic" }, processorFactoryMock.Object) { CallBase = true };
         _subject = subjectMock.Object;
     }
 

--- a/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaGroupLoopConsumerTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Kafka.Test/Consumer/KafkaGroupLoopConsumerTests.cs
@@ -1,0 +1,77 @@
+﻿namespace SlimMessageBus.Host.Kafka.Test;
+
+public class KafkaLoopGroupConsumerTests
+{
+    private readonly KafkaGroupConsumer _subject;
+    
+    private const string GROUP = "group-a";
+    
+    private const string TOPIC = "topic-a";
+    
+    private readonly Mock<IKafkaLoopFailureInterceptor> _mockFailureInterceptor;
+    
+    private readonly Exception _expectedException = new InvalidOperationException("Test fatal error");
+    
+    public KafkaLoopGroupConsumerTests()
+    {
+        ILoggerFactory loggerFactory = NullLoggerFactory.Instance;
+
+        var consumerSettings = new List<AbstractConsumerSettings>
+        {
+            new ConsumerSettings
+            {
+                Path = TOPIC
+            }
+        }.AsReadOnly();
+        
+        var mockKafkaConsumer = new Mock<IConsumer<Ignore, byte[]>>();
+        
+        mockKafkaConsumer
+            .Setup(x => x.Consume(It.IsAny<CancellationToken>()))
+            .Throws(_expectedException);
+        
+        var mockProcessorFactory = new Mock<Func<TopicPartition, IKafkaCommitController, IKafkaPartitionConsumer>>();
+        _mockFailureInterceptor = new Mock<IKafkaLoopFailureInterceptor>();
+        
+        var mockConsumerBuilder = new Mock<ConsumerBuilder<Ignore, byte[]>>(new Dictionary<string, string>() );
+        
+        mockConsumerBuilder
+            .Setup(builder => builder.Build()) 
+            .Returns(mockKafkaConsumer.Object);
+        
+        var mockConsumerBuilderFactory = new Mock<Func<ConsumerConfig, ConsumerBuilder<Ignore, byte[]>>>(); 
+        mockConsumerBuilderFactory
+            .Setup(factory => factory(It.IsAny<ConsumerConfig>()))
+            .Returns(mockConsumerBuilder.Object);
+        
+        var settings = new KafkaMessageBusSettings
+        {
+            ConsumerBuilderFactory = mockConsumerBuilderFactory.Object
+        };
+        
+        _subject = new KafkaGroupConsumer(loggerFactory,
+            settings,
+            consumerSettings,
+            [],
+            [_mockFailureInterceptor.Object],
+            GROUP,
+            [TOPIC], mockProcessorFactory.Object);
+    }
+
+    [Fact]
+    public async Task When_LoopExceptionThrown_Then_ShouldIntercept()
+    {
+        await _subject.Start();
+        await Task.Delay(100); 
+
+        await _subject.Stop();
+
+        _mockFailureInterceptor.Verify(
+            x => x.OnFailureAsync(It.Is<KafkaLoopFailureContext>(ctx =>
+                ctx.Group == GROUP && ctx.Exception == _expectedException)),
+            Times.Once,
+            "Expected IKafkaGroupLoopFailureInterceptor.OnFailureAsync to be called once."
+        );
+    }
+
+}


### PR DESCRIPTION
### A new mechanism to intercept fatal exceptions occurring within the Kafka consumer group loop in KafkaGroupConsumer

A new interface IKafkaLoopFailureInterceptor was added. This interface defines a single method, OnFailureAsync, which is designed to be called when an unhandled exception terminates the main consumer group loop.
The ConsumerLoop method was modified. Inside its final catch (Exception e) block (which handles fatal errors), the code now creates a KafkaLoopFailureContext containing the consumer group name and the exception.
New Context Class (KafkaLoopFailureContext): A simple data class KafkaLoopFailureContext was introduced to encapsulate the information available when a fatal failure occurs: the Kafka consumer group ID and the exception itself.

Tests: Unit tests were added to verify that the IKafkaLoopFailureInterceptor.OnFailureAsync method is correctly invoked when a fatal exception occurs within the ConsumerLoop, ensuring the new functionality works as intended.

