### PR TITLE
Fix outbox failed batch retry loop

### DIFF
--- a/src/SlimMessageBus.Host.Outbox/Services/OutboxSendingTask.cs
+++ b/src/SlimMessageBus.Host.Outbox/Services/OutboxSendingTask.cs
@@ -237,6 +237,7 @@ internal class OutboxSendingTask<TOutboxMessage>(
         const int defaultBatchSize = 50;
 
         var runAgain = outboxMessages.Count == _outboxSettings.PollBatchSize;
+        var failed = false;
         var count = 0;
 
         var aborted = new List<TOutboxMessage>(_outboxSettings.PollBatchSize);
@@ -291,7 +292,7 @@ internal class OutboxSendingTask<TOutboxMessage>(
                 foreach (var batch in batches)
                 {
                     var (success, published) = await DispatchBatch(outboxRepository, bulkProducer, messageBusTarget, batch, busName, path, cancellationToken);
-                    runAgain |= !success;
+                    failed |= !success;
                     count += published;
                 }
             }
@@ -302,7 +303,7 @@ internal class OutboxSendingTask<TOutboxMessage>(
             await outboxRepository.AbortDelivery(aborted, cancellationToken);
         }
 
-        return (runAgain, count);
+        return (!failed && runAgain, count);
     }
 
     async internal Task<(bool Success, int Published)> DispatchBatch(IOutboxMessageRepository<TOutboxMessage> outboxRepository, ITransportBulkProducer producer, IMessageBusTarget messageBusTarget, IReadOnlyCollection<OutboxBulkMessage> batch, string busName, string path, CancellationToken cancellationToken)

--- a/src/SlimMessageBus.Host.Outbox/SlimMessageBus.Host.Outbox.csproj
+++ b/src/SlimMessageBus.Host.Outbox/SlimMessageBus.Host.Outbox.csproj
@@ -14,6 +14,7 @@
 
 	<ItemGroup>
     <InternalsVisibleTo Include="SlimMessageBus.Host.Outbox.Test" />
+    <InternalsVisibleTo Include="SlimMessageBus.Host.Outbox.PostgreSql.Test" />
     <InternalsVisibleTo Include="SlimMessageBus.Host.Outbox.Sql.DbContext.Test" />
     <InternalsVisibleTo Include="SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />

--- a/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.Test/PostgreSqlOutboxRepositoryTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.Test/PostgreSqlOutboxRepositoryTests.cs
@@ -172,6 +172,76 @@ public static class PostgreSqlOutboxRepositoryTests
         }
     }
 
+    public class SendMessagesTests(PostgreSqlFixture postgreSqlFixture) : BasePostgreSqlOutboxRepositoryTest(postgreSqlFixture)
+    {
+        private const string InstanceId = "outbox-sender";
+
+        [Fact]
+        public async Task FailedBatch_IsNotRetriedImmediatelyWithSameLockInstance()
+        {
+            // arrange
+            const int messageCount = 5;
+            const int maxDeliveryAttempts = 3;
+
+            _settings.PollBatchSize = messageCount;
+            _settings.MaxDeliveryAttempts = maxDeliveryAttempts;
+            _settings.LockExpiration = TimeSpan.FromSeconds(5);
+
+            await SeedOutbox(messageCount, (i, message) =>
+            {
+                message.MessageType = typeof(TestOutboxMessage).AssemblyQualifiedName;
+                message.MessagePayload = JsonSerializer.SerializeToUtf8Bytes(new TestOutboxMessage(i));
+            });
+
+            var serializer = new Mock<IMessageSerializer>();
+            serializer
+                .Setup(x => x.Deserialize(typeof(TestOutboxMessage), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<byte[]>(), null))
+                .Returns((Type _, IReadOnlyDictionary<string, object> _, byte[] payload, object _) => JsonSerializer.Deserialize<TestOutboxMessage>(payload));
+
+            var serializerProvider = new Mock<IMessageSerializerProvider>();
+            serializerProvider.Setup(x => x.GetSerializer(It.IsAny<string>())).Returns(serializer.Object);
+
+            var masterBus = new Mock<IMasterMessageBus>();
+            masterBus.Setup(x => x.SerializerProvider).Returns(serializerProvider.Object);
+
+            var bulkProducer = masterBus.As<ITransportBulkProducer>();
+            bulkProducer.Setup(x => x.MaxMessagesPerTransaction).Returns((int?)null);
+            bulkProducer
+                .Setup(x => x.ProduceToTransportBulk(It.IsAny<IReadOnlyCollection<OutboxSendingTask<PostgreSqlOutboxMessage>.OutboxBulkMessage>>(), It.IsAny<string>(), It.IsAny<IMessageBusTarget>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ProduceToTransportBulkResult<OutboxSendingTask<PostgreSqlOutboxMessage>.OutboxBulkMessage>([], new ProducerMessageBusException("Broker unavailable")));
+
+            var messageBus = new Mock<IMessageBusTarget>();
+            messageBus.Setup(x => x.Target).Returns(masterBus.Object);
+
+            var lockRenewalTimer = new Mock<IOutboxLockRenewalTimer>();
+            lockRenewalTimer.Setup(x => x.InstanceId).Returns(InstanceId);
+            lockRenewalTimer.Setup(x => x.LockDuration).Returns(_settings.LockExpiration);
+
+            var lockRenewalTimerFactory = new Mock<IOutboxLockRenewalTimerFactory>();
+            lockRenewalTimerFactory
+                .Setup(x => x.CreateRenewalTimer(It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<Action<Exception>>(), It.IsAny<CancellationToken>()))
+                .Returns(lockRenewalTimer.Object);
+
+            var services = new ServiceCollection()
+                .AddSingleton<IMessageBus>(messageBus.Object)
+                .AddSingleton(lockRenewalTimerFactory.Object)
+                .BuildServiceProvider();
+
+            var target = new OutboxSendingTask<PostgreSqlOutboxMessage>(NullLoggerFactory.Instance, _settings, services);
+
+            // act
+            var published = await target.SendMessages(services, _target, CancellationToken.None);
+            var messages = await _target.GetAllMessages(CancellationToken.None);
+
+            // assert
+            published.Should().Be(0);
+            messages.Should().OnlyContain(x => x.DeliveryAttempt == 1);
+            messages.Should().OnlyContain(x => !x.DeliveryAborted);
+        }
+
+        private sealed record TestOutboxMessage(int Value);
+    }
+
     public class IncrementDeliveryAttemptTests(PostgreSqlFixture postgreSqlFixture) : BasePostgreSqlOutboxRepositoryTest(postgreSqlFixture)
     {
         [Fact]

--- a/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.Test/Usings.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.Test/Usings.cs
@@ -6,14 +6,19 @@ global using AutoFixture;
 
 global using AwesomeAssertions;
 
+global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging.Abstractions;
 global using Microsoft.Extensions.Time.Testing;
 
+global using Moq;
+
 global using Npgsql;
 
+global using SlimMessageBus.Host.Outbox.Services;
 global using SlimMessageBus.Host.Outbox.PostgreSql.Configuration;
 global using SlimMessageBus.Host.Outbox.PostgreSql.Repositories;
 global using SlimMessageBus.Host.Outbox.PostgreSql.Services;
 global using SlimMessageBus.Host.Outbox.PostgreSql.Transactions;
+global using SlimMessageBus.Host.Serialization;
 
 global using Xunit;

--- a/src/Tests/SlimMessageBus.Host.Outbox.Test/Services/OutboxSendingTaskTests.cs
+++ b/src/Tests/SlimMessageBus.Host.Outbox.Test/Services/OutboxSendingTaskTests.cs
@@ -174,6 +174,31 @@ public sealed class OutboxSendingTaskTests
         }
 
         [Fact]
+        public async Task ProcessMessages_ShouldReturnRunAgainFalse_WhenBatchFailsAndOutboxMessagesCountEqualsPollBatchSize()
+        {
+            // Arrange
+            var outboxMessages = CreateOutboxMessages(50);
+            var cancellationToken = CancellationToken.None;
+
+            _mockCompositeMessageBus.Setup(x => x.GetChildBus(It.IsAny<string>())).Returns(_mockMasterMessageBus.Object);
+            _mockMessageBusBulkProducer.Setup(x => x.MaxMessagesPerTransaction).Returns(10);
+
+            _mockMessageBusBulkProducer.Setup(x => x.ProduceToTransportBulk(It.IsAny<IReadOnlyCollection<OutboxBulkMessage>>(), It.IsAny<string>(), It.IsAny<IMessageBusTarget>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((IReadOnlyCollection<OutboxBulkMessage> envelopes, string path, IMessageBusTarget targetBus, CancellationToken cancellationToken) => new ProduceToTransportBulkResult<OutboxBulkMessage>([], new ProducerMessageBusException("Broker unavailable")));
+
+            var mockMessageTypeResolver = new Mock<IMessageTypeResolver>();
+            mockMessageTypeResolver.Setup(x => x.ToType(It.IsAny<string>())).Returns(typeof(object));
+            _outboxSettings.MessageTypeResolver = mockMessageTypeResolver.Object;
+
+            // Act
+            var result = await _sut.ProcessMessages(_mockOutboxRepository.Object, outboxMessages, _mockCompositeMessageBus.Object, _mockMessageBusTarget.Object, cancellationToken);
+
+            // Assert
+            result.RunAgain.Should().BeFalse();
+            result.Count.Should().Be(0);
+        }
+
+        [Fact]
         public async Task ProcessMessages_ShouldAbortDelivery_WhenBusIsNotRecognised()
         {
             // Arrange


### PR DESCRIPTION
## Summary
- Fixes #459 by stopping failed outbox batches from immediately re-entering the same sending pass.
- Failed messages still have delivery attempts recorded, but the next retry is governed by the outbox polling/lock timing instead of a tight same-instance loop.
- Adds core outbox unit coverage and PostgreSQL/Testcontainers integration coverage for the retry behavior.

## Tests
- dotnet test src\Tests\SlimMessageBus.Host.Outbox.Test\SlimMessageBus.Host.Outbox.Test.csproj --no-build -v minimal -m:1
- dotnet test src\Tests\SlimMessageBus.Host.Outbox.PostgreSql.Test\SlimMessageBus.Host.Outbox.PostgreSql.Test.csproj --no-build -v minimal -m:1