### PR TITLE
Bump dependency versions

### DIFF
--- a/src/Common.NuGet.Properties.xml
+++ b/src/Common.NuGet.Properties.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Common.Properties.xml" />
 

--- a/src/Host.Plugin.Properties.xml
+++ b/src/Host.Plugin.Properties.xml
@@ -3,6 +3,6 @@
   <Import Project="Common.NuGet.Properties.xml" />
 
   <PropertyGroup>
-    <Version>3.5.0-rc103</Version>
+    <Version>3.5.0</Version>
   </PropertyGroup>
 </Project>

--- a/src/Samples/Sample.AsyncApi.Service/Sample.AsyncApi.Service.csproj
+++ b/src/Samples/Sample.AsyncApi.Service/Sample.AsyncApi.Service.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
-    <PackageReference Include="NSwag.AspNetCore" Version="14.6.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="NSwag.AspNetCore" Version="14.7.1" />
     <ProjectReference Include="..\..\SlimMessageBus.Host.AsyncApi\SlimMessageBus.Host.AsyncApi.csproj" />
     <ProjectReference Include="..\..\SlimMessageBus.Host.AzureServiceBus\SlimMessageBus.Host.AzureServiceBus.csproj" />
     <ProjectReference Include="..\..\SlimMessageBus.Host.Kafka\SlimMessageBus.Host.Kafka.csproj" />

--- a/src/Samples/Sample.CircuitBreaker.HealthCheck/Sample.CircuitBreaker.HealthCheck.csproj
+++ b/src/Samples/Sample.CircuitBreaker.HealthCheck/Sample.CircuitBreaker.HealthCheck.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sample.DomainEvents.Application/Sample.DomainEvents.Application.csproj
+++ b/src/Samples/Sample.DomainEvents.Application/Sample.DomainEvents.Application.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sample.DomainEvents.Domain/Sample.DomainEvents.Domain.csproj
+++ b/src/Samples/Sample.DomainEvents.Domain/Sample.DomainEvents.Domain.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sample.DomainEvents.WebApi/Sample.DomainEvents.WebApi.csproj
+++ b/src/Samples/Sample.DomainEvents.WebApi/Sample.DomainEvents.WebApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sample.Hybrid.ConsoleApp/Sample.Hybrid.ConsoleApp.csproj
+++ b/src/Samples/Sample.Hybrid.ConsoleApp/Sample.Hybrid.ConsoleApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sample.Images.WebApi/Sample.Images.WebApi.csproj
+++ b/src/Samples/Sample.Images.WebApi/Sample.Images.WebApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sample.Images.Worker/Sample.Images.Worker.csproj
+++ b/src/Samples/Sample.Images.Worker/Sample.Images.Worker.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sample.Nats.WebApi/Sample.Nats.WebApi.csproj
+++ b/src/Samples/Sample.Nats.WebApi/Sample.Nats.WebApi.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.1" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Samples/Sample.OutboxWebApi/Sample.OutboxWebApi.csproj
+++ b/src/Samples/Sample.OutboxWebApi/Sample.OutboxWebApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sample.Serialization.ConsoleApp/Sample.Serialization.ConsoleApp.csproj
+++ b/src/Samples/Sample.Serialization.ConsoleApp/Sample.Serialization.ConsoleApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Samples/Sample.Simple.ConsoleApp/Sample.ConsoleApp.csproj
+++ b/src/Samples/Sample.Simple.ConsoleApp/Sample.ConsoleApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sample.ValidatingWebApi/Sample.ValidatingWebApi.csproj
+++ b/src/Samples/Sample.ValidatingWebApi/Sample.ValidatingWebApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.AmazonSQS/SlimMessageBus.Host.AmazonSQS.csproj
+++ b/src/SlimMessageBus.Host.AmazonSQS/SlimMessageBus.Host.AmazonSQS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.10" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.2.17" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.15" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.100.3" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.100.3" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.100.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.AsyncApi/SlimMessageBus.Host.AsyncApi.csproj
+++ b/src/SlimMessageBus.Host.AsyncApi/SlimMessageBus.Host.AsyncApi.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Namotion.Reflection" Version="3.4.3" />
+    <PackageReference Include="Namotion.Reflection" Version="3.5.1" />
     <PackageReference Include="Saunter" Version="0.13.0" />
   </ItemGroup>
 

--- a/src/SlimMessageBus.Host.CircuitBreaker.HealthCheck/SlimMessageBus.Host.CircuitBreaker.HealthCheck.csproj
+++ b/src/SlimMessageBus.Host.CircuitBreaker.HealthCheck/SlimMessageBus.Host.CircuitBreaker.HealthCheck.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.36" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.14" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.9" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
+++ b/src/SlimMessageBus.Host.Configuration/SlimMessageBus.Host.Configuration.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Common.NuGet.Properties.xml" />
 
   <PropertyGroup>
     <Description>Core configuration interfaces of SlimMessageBus</Description>
     <PackageTags>SlimMessageBus</PackageTags>
     <RootNamespace>SlimMessageBus.Host</RootNamespace>
-    <Version>3.5.0-rc103</Version>
+    <Version>3.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,7 +26,7 @@
     />
     <PackageReference
       Include="Microsoft.Extensions.DependencyInjection.Abstractions"
-      Version="10.0.3"
+      Version="10.0.9"
       Condition="'$(TargetFramework)' == 'net10.0'"
     />
   </ItemGroup>

--- a/src/SlimMessageBus.Host.FluentValidation/SlimMessageBus.Host.FluentValidation.csproj
+++ b/src/SlimMessageBus.Host.FluentValidation/SlimMessageBus.Host.FluentValidation.csproj
@@ -1,15 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Description>Extensions for SlimMessageBus that adds validation to the producer or consumer side based on the FluentValidation library</Description>
     <PackageTags>SlimMessageBus MessageBus FluentValidation Validation</PackageTags>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.12.0" />
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Kafka/SlimMessageBus.Host.Kafka.csproj
+++ b/src/SlimMessageBus.Host.Kafka/SlimMessageBus.Host.Kafka.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.13.2" />
+    <PackageReference Include="Confluent.Kafka" Version="2.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Mqtt/SlimMessageBus.Host.Mqtt.csproj
+++ b/src/SlimMessageBus.Host.Mqtt/SlimMessageBus.Host.Mqtt.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
+    <PackageReference Include="MQTTnet" Version="5.2.0.1603" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Nats/SlimMessageBus.Host.Nats.csproj
+++ b/src/SlimMessageBus.Host.Nats/SlimMessageBus.Host.Nats.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NATS.Net" Version="2.7.2" />
+    <PackageReference Include="NATS.Net" Version="2.8.2" />
   </ItemGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Outbox.MongoDb/SlimMessageBus.Host.Outbox.MongoDb.csproj
+++ b/src/SlimMessageBus.Host.Outbox.MongoDb/SlimMessageBus.Host.Outbox.MongoDb.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.10.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Outbox.PostgreSql.DbContext/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.csproj
+++ b/src/SlimMessageBus.Host.Outbox.PostgreSql.DbContext/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Description>Plugin for SlimMessageBus that adds Transactional Outbox pattern support using Entity Framework with PostgreSQL</Description>
     <PackageTags>SlimMessageBus MessageBus Transactional Outbox PostgreSQL Entity Framework EF</PackageTags>
     <Nullable>enable</Nullable>
@@ -18,7 +19,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.29" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.18" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Outbox.PostgreSql/SlimMessageBus.Host.Outbox.PostgreSql.csproj
+++ b/src/SlimMessageBus.Host.Outbox.PostgreSql/SlimMessageBus.Host.Outbox.PostgreSql.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Description>Plugin for SlimMessageBus that adds Transactional Outbox pattern support using PostgresSQL database</Description>
     <PackageTags>SlimMessageBus MessageBus Transactional Outbox PostgreSQL</PackageTags>
     <Nullable>enable</Nullable>
@@ -21,8 +22,8 @@
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Npgsql" Version="9.0.3" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Npgsql" Version="9.0.3" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageReference Include="Npgsql" Version="9.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Npgsql" Version="9.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Npgsql" Version="10.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Npgsql" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Outbox.Sql.DbContext/SlimMessageBus.Host.Outbox.Sql.DbContext.csproj
+++ b/src/SlimMessageBus.Host.Outbox.Sql.DbContext/SlimMessageBus.Host.Outbox.Sql.DbContext.csproj
@@ -3,6 +3,7 @@
   <Import Project="../Host.Plugin.Properties.xml" />
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0;net6.0</TargetFrameworks>
     <Description>Plugin for SlimMessageBus that adds Transactional Outbox pattern support using Entity Framework</Description>
     <PackageTags>SlimMessageBus MessageBus Transactional Outbox SQL Entity Framework EF</PackageTags>
   </PropertyGroup>
@@ -15,7 +16,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.1" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Outbox.Sql/SlimMessageBus.Host.Outbox.Sql.csproj
+++ b/src/SlimMessageBus.Host.Outbox.Sql/SlimMessageBus.Host.Outbox.Sql.csproj
@@ -3,6 +3,7 @@
   <Import Project="../Host.Plugin.Properties.xml" />
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0;net6.0</TargetFrameworks>
     <Description>Plugin for SlimMessageBus that adds Transactional Outbox pattern support using SQL database</Description>
     <PackageTags>SlimMessageBus MessageBus Transactional Outbox SQL</PackageTags>
   </PropertyGroup>

--- a/src/SlimMessageBus.Host.PostgreSql/SlimMessageBus.Host.PostgreSql.csproj
+++ b/src/SlimMessageBus.Host.PostgreSql/SlimMessageBus.Host.PostgreSql.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Npgsql" Version="9.0.3" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Npgsql" Version="9.0.3" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageReference Include="Npgsql" Version="9.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Npgsql" Version="9.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Npgsql" Version="10.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Npgsql" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Redis/SlimMessageBus.Host.Redis.csproj
+++ b/src/SlimMessageBus.Host.Redis/SlimMessageBus.Host.Redis.csproj
@@ -3,6 +3,7 @@
   <Import Project="../Host.Plugin.Properties.xml" />
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Description>Redis transport provider for SlimMessageBus</Description>
     <PackageTags>Redis transport provider SlimMessageBus MessageBus bus facade messaging client</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
@@ -10,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.11.8" />
+    <PackageReference Include="StackExchange.Redis" Version="3.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Serialization.Avro/SlimMessageBus.Host.Serialization.Avro.csproj
+++ b/src/SlimMessageBus.Host.Serialization.Avro/SlimMessageBus.Host.Serialization.Avro.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Serialization.GoogleProtobuf/SlimMessageBus.Host.Serialization.GoogleProtobuf.csproj
+++ b/src/SlimMessageBus.Host.Serialization.GoogleProtobuf/SlimMessageBus.Host.Serialization.GoogleProtobuf.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.34.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.35.1" />
 
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SlimMessageBus.Host.Serialization.Hybrid/SlimMessageBus.Host.Serialization.Hybrid.csproj
+++ b/src/SlimMessageBus.Host.Serialization.Hybrid/SlimMessageBus.Host.Serialization.Hybrid.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<Import Project="../Host.Plugin.Properties.xml" />
 
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" Condition="'$(TargetFramework)' == 'net10.0'" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SlimMessageBus.Host.Serialization.Json/SlimMessageBus.Host.Serialization.Json.csproj
+++ b/src/SlimMessageBus.Host.Serialization.Json/SlimMessageBus.Host.Serialization.Json.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" Condition="'$(TargetFramework)' == 'net10.0'" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>

--- a/src/SlimMessageBus.Host.Sql.Common/SlimMessageBus.Host.Sql.Common.csproj
+++ b/src/SlimMessageBus.Host.Sql.Common/SlimMessageBus.Host.Sql.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 
@@ -14,7 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" Condition="'$(TargetFramework)' == 'net10.0' Or '$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
 </Project>

--- a/src/SlimMessageBus.Host.Sql/SlimMessageBus.Host.Sql.csproj
+++ b/src/SlimMessageBus.Host.Sql/SlimMessageBus.Host.Sql.csproj
@@ -3,6 +3,7 @@
   <Import Project="../Host.Plugin.Properties.xml" />
 
   <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Description>SQL Server transport provider for SlimMessageBus</Description>
     <PackageTags>SQL Server transport provider SlimMessageBus MessageBus bus facade messaging client</PackageTags>
     <PackageIcon>icon.png</PackageIcon>

--- a/src/SlimMessageBus.Host/SlimMessageBus.Host.csproj
+++ b/src/SlimMessageBus.Host/SlimMessageBus.Host.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Plugin.Properties.xml" />
 
@@ -17,12 +17,12 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" Condition="'$(TargetFramework)' == 'net10.0'" />
 
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Host.Test.Properties.xml
+++ b/src/Tests/Host.Test.Properties.xml
@@ -18,8 +18,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   

--- a/src/Tests/SlimMessageBus.Host.AspNetCore.Test/SlimMessageBus.Host.AspNetCore.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.AspNetCore.Test/SlimMessageBus.Host.AspNetCore.Test.csproj
@@ -3,7 +3,7 @@
   <Import Project="../Host.Test.Properties.xml" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/SlimMessageBus.Host.Memory.Benchmark/SlimMessageBus.Host.Memory.Benchmark.csproj
+++ b/src/Tests/SlimMessageBus.Host.Memory.Benchmark/SlimMessageBus.Host.Memory.Benchmark.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Test.Properties.xml" />
 
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/SlimMessageBus.Host.Outbox.MongoDb.Test/SlimMessageBus.Host.Outbox.MongoDb.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Outbox.MongoDb.Test/SlimMessageBus.Host.Outbox.MongoDb.Test.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Testcontainers.MongoDb" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.MongoDb" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test/SlimMessageBus.Host.Outbox.PostgreSql.DbContext.Test.csproj
@@ -1,16 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Test.Properties.xml" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    <PackageReference Include="Testcontainers.Kafka" Version="4.10.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
-    <PackageReference Include="Testcontainers.RabbitMq" Version="4.10.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.13.0" />
+    <PackageReference Include="Testcontainers.RabbitMq" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.Test/SlimMessageBus.Host.Outbox.PostgreSql.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Outbox.PostgreSql.Test/SlimMessageBus.Host.Outbox.PostgreSql.Test.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/SlimMessageBus.Host.Outbox.Sql.DbContext.Test/SlimMessageBus.Host.Outbox.Sql.DbContext.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Outbox.Sql.DbContext.Test/SlimMessageBus.Host.Outbox.Sql.DbContext.Test.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Test.Properties.xml" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/SlimMessageBus.Host.Outbox.Sql.Test/SlimMessageBus.Host.Outbox.Sql.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Outbox.Sql.Test/SlimMessageBus.Host.Outbox.Sql.Test.csproj
@@ -8,7 +8,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Testcontainers.MsSql" Version="4.10.0" />
+	  <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Tests/SlimMessageBus.Host.PostgreSql.Test/SlimMessageBus.Host.PostgreSql.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.PostgreSql.Test/SlimMessageBus.Host.PostgreSql.Test.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/SlimMessageBus.Host.Relational.Benchmark/SlimMessageBus.Host.Relational.Benchmark.csproj
+++ b/src/Tests/SlimMessageBus.Host.Relational.Benchmark/SlimMessageBus.Host.Relational.Benchmark.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.10.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/SlimMessageBus.Host.Serialization.Avro.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Avro.Test/SlimMessageBus.Host.Serialization.Avro.Test.csproj
@@ -3,7 +3,7 @@
   <Import Project="../Host.Test.Properties.xml" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,6 +15,10 @@
   </ItemGroup>
 
    <ItemGroup>
+     <PackageReference Update="coverlet.collector" Version="10.0.1">
+       <PrivateAssets>all</PrivateAssets>
+       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+     </PackageReference>
      <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
    </ItemGroup>
 

--- a/src/Tests/SlimMessageBus.Host.Serialization.Benchmark/SlimMessageBus.Host.Serialization.Benchmark.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Benchmark/SlimMessageBus.Host.Serialization.Benchmark.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 

--- a/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test/SlimMessageBus.Host.Serialization.GoogleProtobuf.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Test.Properties.xml" />
 
@@ -7,12 +7,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.78.0">
+    <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.82.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,7 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Update="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SlimMessageBus.Host.Serialization.Hybrid.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Hybrid.Test/SlimMessageBus.Host.Serialization.Hybrid.Test.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Test.Properties.xml" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 

--- a/src/Tests/SlimMessageBus.Host.Serialization.Json.Test/SlimMessageBus.Host.Serialization.Json.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.Json.Test/SlimMessageBus.Host.Serialization.Json.Test.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Test.Properties.xml" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 

--- a/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/SlimMessageBus.Host.Serialization.SystemTextJson.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Serialization.SystemTextJson.Test/SlimMessageBus.Host.Serialization.SystemTextJson.Test.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Test.Properties.xml" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 

--- a/src/Tests/SlimMessageBus.Host.Sql.Test/SlimMessageBus.Host.Sql.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Sql.Test/SlimMessageBus.Host.Sql.Test.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Testcontainers.MsSql" Version="4.10.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 

--- a/src/Tests/SlimMessageBus.Host.Test.Common/SlimMessageBus.Host.Test.Common.csproj
+++ b/src/Tests/SlimMessageBus.Host.Test.Common/SlimMessageBus.Host.Test.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../Host.Test.Properties.xml" />
 
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.19" />
   </ItemGroup>
 
@@ -23,7 +23,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Update="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/SlimMessageBus.Host.Test/SlimMessageBus.Host.Test.csproj
+++ b/src/Tests/SlimMessageBus.Host.Test/SlimMessageBus.Host.Test.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 

--- a/src/Tests/SlimMessageBus.Test/SlimMessageBus.Test.csproj
+++ b/src/Tests/SlimMessageBus.Test/SlimMessageBus.Test.csproj
@@ -8,6 +8,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- bump direct package references across transports, samples, and tests
- keep compatibility-conditioned package versions where latest packages do not support older target frameworks
- narrow Redis to net10.0/net8.0 for latest StackExchange.Redis

## Verification
- dotnet build src/SlimMessageBus.sln --no-restore -v minimal -m:1 -p:UseSharedCompilation=false -nodeReuse:false