### PR TITLE
[Host.RabbitMq] Handle RabbitMQ RPC deserialization failures

### DIFF
--- a/src/Host.Plugin.Properties.xml
+++ b/src/Host.Plugin.Properties.xml
@@ -3,6 +3,6 @@
   <Import Project="Common.NuGet.Properties.xml" />
 
   <PropertyGroup>
-    <Version>3.5.0</Version>
+    <Version>3.6.0-rc100</Version>
   </PropertyGroup>
 </Project>

--- a/src/SlimMessageBus.Host.RabbitMQ/Consumers/RabbitMqConsumer.cs
+++ b/src/SlimMessageBus.Host.RabbitMQ/Consumers/RabbitMqConsumer.cs
@@ -55,7 +55,7 @@ public class RabbitMqConsumer : AbstractRabbitMqConsumer, IRabbitMqConsumer
             // pick the maximum number of instances
             var instances = consumers.Max(x => x.Instances);
             // For a given rabbit channel, there is only 1 task that dispatches messages. We want to be able to let each SMB consume process within its own task (1 or more)
-            messageProcessor = new ConcurrentMessageProcessorDecorator<BasicDeliverEventArgs>(instances, loggerFactory, messageProcessor);
+            messageProcessor = new ConcurrentMessageProcessorDecorator<BasicDeliverEventArgs>(instances, loggerFactory, messageProcessor, reportBackgroundExceptions: false);
 
             return messageProcessor;
         }

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/ConcurrentMessageProcessorDecorator.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/ConcurrentMessageProcessorDecorator.cs
@@ -13,6 +13,7 @@ public sealed partial class ConcurrentMessageProcessorDecorator<TMessage> : IMes
     private Exception _lastException;
     private TMessage _lastExceptionMessage;
     private AbstractConsumerSettings _lastExceptionSettings;
+    private readonly bool _reportBackgroundExceptions;
     private readonly object _lastExceptionLock = new();
 
     private int _pendingCount;
@@ -21,7 +22,7 @@ public sealed partial class ConcurrentMessageProcessorDecorator<TMessage> : IMes
 
     public IReadOnlyCollection<AbstractConsumerSettings> ConsumerSettings => _target.ConsumerSettings;
 
-    public ConcurrentMessageProcessorDecorator(int concurrency, ILoggerFactory loggerFactory, IMessageProcessor<TMessage> target)
+    public ConcurrentMessageProcessorDecorator(int concurrency, ILoggerFactory loggerFactory, IMessageProcessor<TMessage> target, bool reportBackgroundExceptions = true)
     {
         if (target is null) throw new ArgumentNullException(nameof(target));
         if (loggerFactory is null) throw new ArgumentNullException(nameof(loggerFactory));
@@ -30,6 +31,7 @@ public sealed partial class ConcurrentMessageProcessorDecorator<TMessage> : IMes
         _logger = loggerFactory.CreateLogger<ConcurrentMessageProcessorDecorator<TMessage>>();
         _concurrentSemaphore = new SemaphoreSlim(concurrency);
         _target = target;
+        _reportBackgroundExceptions = reportBackgroundExceptions;
     }
 
     #region IDisposable
@@ -90,7 +92,7 @@ public sealed partial class ConcurrentMessageProcessorDecorator<TMessage> : IMes
             LogEntering(typeof(TMessage));
 
             var r = await _target.ProcessMessage(transportMessage, messageHeaders, consumerContextProperties, currentServiceProvider, cancellationToken).ConfigureAwait(false);
-            if (r.Exception != null)
+            if (_reportBackgroundExceptions && r.Exception != null)
             {
                 lock (_lastExceptionLock)
                 {

--- a/src/SlimMessageBus.Host/Consumer/MessageProcessors/MessageProcessor.cs
+++ b/src/SlimMessageBus.Host/Consumer/MessageProcessors/MessageProcessor.cs
@@ -86,6 +86,7 @@ public partial class MessageProcessor<TTransportMessage> : MessageHandler, IMess
         Exception lastException = null;
         object lastResponse = null;
         Type messageType = null;
+        IReadOnlyCollection<IMessageTypeConsumerInvokerSettings> consumerInvokers = null;
 
         try
         {
@@ -95,11 +96,10 @@ public partial class MessageProcessor<TTransportMessage> : MessageHandler, IMess
 
             if (messageType != null)
             {
+                consumerInvokers = [.. TryMatchConsumerInvoker(messageType, messageHeaders, transportMessage)];
                 var message = _messageProvider(messageType, messageHeaders, transportMessage);
                 try
                 {
-                    var consumerInvokers = TryMatchConsumerInvoker(messageType, messageHeaders, transportMessage);
-
                     foreach (var consumerInvoker in consumerInvokers)
                     {
                         lastConsumerInvoker = consumerInvoker;
@@ -148,6 +148,31 @@ public partial class MessageProcessor<TTransportMessage> : MessageHandler, IMess
             LogProcessingMessageFailedTypeKnown(transportMessage, messageType, e);
             lastException ??= e;
             result = ProcessResult.Failure;
+
+            if (consumerInvokers != null)
+            {
+                var consumerInvoker = consumerInvokers.FirstOrDefault(x => x.ParentSettings.ConsumerMode == ConsumerMode.RequestResponse);
+                if (consumerInvoker != null)
+                {
+                    lastConsumerInvoker = consumerInvoker;
+
+                    if (_responseProducer != null && messageHeaders != null)
+                    {
+                        messageHeaders.TryGetHeader(ReqRespMessageHeaders.RequestId, out string requestId);
+                        try
+                        {
+                            await _responseProducer.ProduceResponse(requestId, null, messageHeaders, null, e, consumerInvoker, cancellationToken).ConfigureAwait(false);
+
+                            // Clear the exception as it will be returned to the sender.
+                            lastException = null;
+                        }
+                        catch
+                        {
+                            // Keep the original exception so the transport can handle the failed message.
+                        }
+                    }
+                }
+            }
         }
         return new(result, lastException, lastException != null ? lastConsumerInvoker?.ParentSettings : null, lastResponse);
     }

--- a/src/Tests/SlimMessageBus.Host.Test/Consumer/ConcurrentMessageProcessorDecoratorTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Consumer/ConcurrentMessageProcessorDecoratorTest.cs
@@ -159,6 +159,42 @@ public class ConcurrentMessageProcessorDecoratorTest
     }
 
     [Fact]
+    public async Task When_ProcessMessage_Given_BackgroundExceptionReportingDisabled_Then_ExceptionIsNotReportedOnSecondInvocation()
+    {
+        // arrange
+        var subject = new ConcurrentMessageProcessorDecorator<SomeMessage>(1, NullLoggerFactory.Instance, _messageProcessorMock.Object, reportBackgroundExceptions: false);
+
+        var exception = new Exception("Boom!");
+        var firstCallCompleted = new TaskCompletionSource<bool>();
+        var callCount = 0;
+
+        _messageProcessorMock
+            .Setup(x => x.ProcessMessage(It.IsAny<SomeMessage>(), It.IsAny<IReadOnlyDictionary<string, object>>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<IServiceProvider>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                if (Interlocked.Increment(ref callCount) == 1)
+                {
+                    firstCallCompleted.TrySetResult(true);
+                }
+                return Task.FromResult(new ProcessMessageResult(ProcessResult.Failure, exception, null, null));
+            });
+
+        var msg = new SomeMessage();
+        var msgHeaders = new Dictionary<string, object>();
+        await subject.ProcessMessage(msg, msgHeaders, default);
+        await firstCallCompleted.Task;
+        await subject.WaitAll(CancellationToken.None);
+
+        // act
+        var result = await subject.ProcessMessage(msg, msgHeaders, default);
+        await subject.WaitAll(CancellationToken.None);
+
+        // assert
+        result.Exception.Should().BeNull();
+        callCount.Should().Be(2);
+    }
+
+    [Fact]
     public async Task When_ProcessMessage_Given_ExceptionHappensOnTarget_Then_SemaphoreIsNotLeakedAndProcessingContinues()
     {
         // arrange
@@ -214,4 +250,3 @@ public class ConcurrentMessageProcessorDecoratorTest
         subject.PendingCount.Should().Be(0); // All processing should complete
     }
 }
-

--- a/src/Tests/SlimMessageBus.Host.Test/Consumer/MessageProcessorTest.cs
+++ b/src/Tests/SlimMessageBus.Host.Test/Consumer/MessageProcessorTest.cs
@@ -36,6 +36,7 @@ public class MessageProcessorTest
         messageProviderMock = new Mock<MessageProvider<SomeMessage>>();
 
         consumerBuilder = new ConsumerBuilder<SomeMessage>(new MessageBusSettings());
+        consumerBuilder.WithConsumer<SomeMessageConsumer>();
 
         subject = new Lazy<MessageProcessor<SomeMessage>>(
             () => new MessageProcessor<SomeMessage>(
@@ -73,6 +74,54 @@ public class MessageProcessorTest
         result.Should().NotBeNull();
         result.Result.Should().Be(ProcessResult.Failure);
         result.Exception.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task When_ProcessMessage_Given_RequestPayloadCannotDeserialize_Then_ErrorResponseIsSent()
+    {
+        // arrange
+        var transportMessageMock = new Mock<SomeMessage>();
+        var headers = new Dictionary<string, object>
+        {
+            { MessageHeaders.MessageType, typeof(SomeRequest).AssemblyQualifiedName },
+            { ReqRespMessageHeaders.RequestId, "request-id" },
+            { ReqRespMessageHeaders.ReplyTo, "reply-to" }
+        };
+
+        var deserializationException = new InvalidOperationException("Deserialization failed");
+        var handlerBuilder = new HandlerBuilder<SomeRequest, SomeResponse>(new MessageBusSettings());
+        handlerBuilder.WithHandler<SomeRequestMessageHandler>();
+
+        var subject = new MessageProcessor<SomeMessage>(
+            consumerSettings: [handlerBuilder.ConsumerSettings],
+            messageBus: busMock.Bus,
+            messageProvider: messageProviderMock.Object,
+            path: "topic1",
+            responseProducer: responseProducerMock.Object);
+
+        messageProviderMock
+            .Setup(x => x.Invoke(typeof(SomeRequest), headers, transportMessageMock.Object))
+            .Throws(deserializationException);
+
+        // act
+        var result = await subject.ProcessMessage(transportMessageMock.Object, headers);
+
+        // assert
+        messageProviderMock.Verify(x => x(typeof(SomeRequest), headers, transportMessageMock.Object), Times.Once);
+        responseProducerMock.Verify(
+            x => x.ProduceResponse(
+                "request-id",
+                null,
+                headers,
+                null,
+                deserializationException,
+                handlerBuilder.ConsumerSettings,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        result.Should().NotBeNull();
+        result.Result.Should().Be(ProcessResult.Failure);
+        result.Exception.Should().BeNull();
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- send request/response error replies when request deserialization fails before handler invocation
- keep RabbitMQ from replaying background processing failures onto the next delivery, avoiding stuck unacked malformed messages
- add focused processor and concurrent decorator coverage

Fixes #480

## Tests
- dotnet test src\Tests\SlimMessageBus.Host.Test\SlimMessageBus.Host.Test.csproj --no-restore -v minimal -p:UseSharedCompilation=false -m:1 -nodeReuse:false
- dotnet test src\Tests\SlimMessageBus.Host.RabbitMQ.Test\SlimMessageBus.Host.RabbitMQ.Test.csproj --no-restore -v minimal --filter "FullyQualifiedName!~IntegrationTests" -p:UseSharedCompilation=false -m:1 -nodeReuse:false

Note: full RabbitMQ integration tests require a local broker on 127.0.0.1:5672; without it they fail with BrokerUnreachableException.